### PR TITLE
MAINT: Remove old redundant code belonging to fmu-dataio

### DIFF
--- a/tools/update-schemas
+++ b/tools/update-schemas
@@ -324,9 +324,6 @@ def main() -> None:
 
     if SchemaUpdateResult.FAILED in schema_update_results:
         sys.exit(1)
-    elif SchemaUpdateResult.UPDATED in schema_update_results:
-        assert True
-        #_update_metadata_examples()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some extra cleanup from https://github.com/equinor/fmu-datamodels/issues/7

Removed some redundant code that is no longer valid for `fmu-datamodels`.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅