### PR TITLE
MAINT: Correct wrong realization name in field example

### DIFF
--- a/schemas/0.14.0/fmu_results.json
+++ b/schemas/0.14.0/fmu_results.json
@@ -6830,7 +6830,7 @@
         },
         "name": {
           "examples": [
-            "iter-0"
+            "realization-0"
           ],
           "title": "Name",
           "type": "string"

--- a/src/fmu/datamodels/fmu_results/fields.py
+++ b/src/fmu/datamodels/fmu_results/fields.py
@@ -262,7 +262,7 @@ class Realization(BaseModel):
     id: int = Field(ge=0)
     """The internal ID of the realization, represented by an integer."""
 
-    name: str = Field(examples=["iter-0"])
+    name: str = Field(examples=["realization-0"])
     """The name of the realization. This is typically reflecting the folder name on
     scratch. We recommend to use ``fmu.realization.id`` for all usage except purely
     visual appearance."""

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -50,6 +50,8 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.14.0
 
+    - Correct example name for realization class
+
     #### 0.13.0
 
     - Content 'fault_triangulated_surface' renamed to 'fault_surface'


### PR DESCRIPTION
Resolves #9 

Corrects the example name for the `Realization` class from `iter-0` -> `realization-0`

## Checklist

- [X] Tests added (if not, comment why): N/A
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅