### PR TITLE
ENH: implement structure_depth_fault_surface standard result

### DIFF
--- a/schemas/0.14.0/fmu_results.json
+++ b/schemas/0.14.0/fmu_results.json
@@ -222,6 +222,9 @@
           "$ref": "#/$defs/StructureDepthSurfaceStandardResult"
         },
         {
+          "$ref": "#/$defs/StructureDepthFaultSurfaceStandardResult"
+        },
+        {
           "$ref": "#/$defs/StructureTimeSurfaceStandardResult"
         },
         {
@@ -8338,6 +8341,32 @@
         "name"
       ],
       "title": "StructureDepthFaultLinesStandardResult",
+      "type": "object"
+    },
+    "StructureDepthFaultSurfaceStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_depth_fault_surface'\nstandard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "structure_depth_fault_surface",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureDepthFaultSurfaceStandardResult",
       "type": "object"
     },
     "StructureDepthIsochoreStandardResult": {

--- a/src/fmu/datamodels/fmu_results/standard_result.py
+++ b/src/fmu/datamodels/fmu_results/standard_result.py
@@ -71,6 +71,18 @@ class StructureDepthSurfaceStandardResult(StandardResult):
     """The identifying name for the 'structure_depth_surface' standard result."""
 
 
+class StructureDepthFaultSurfaceStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represent.
+    This class contains metadata for the 'structure_depth_fault_surface'
+    standard result.
+    """
+
+    name: Literal[enums.StandardResultName.structure_depth_fault_surface]
+    """The identifying name for the 'structure_depth_fault_surface' standard result."""
+
+
 class StructureTimeSurfaceStandardResult(StandardResult):
     """
     The ``standard_result`` field contains information about which standard results this
@@ -177,6 +189,7 @@ class AnyStandardResult(RootModel):
         FieldOutlineStandardResult
         | InplaceVolumesStandardResult
         | StructureDepthSurfaceStandardResult
+        | StructureDepthFaultSurfaceStandardResult
         | StructureTimeSurfaceStandardResult
         | StructureDepthIsochoreStandardResult
         | StructureDepthFaultLinesStandardResult


### PR DESCRIPTION
Partially resolves #https://github.com/equinor/fmu-dataio/issues/1227

Implements structure_depth_fault_surface as a new standard result and updates the schema

## Checklist

- [x] No tests added for this simple enum member
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅