### PR TITLE
SCHEMA: update enums for triangulated surfaces

### DIFF
--- a/schemas/0.15.0/fmu_results.json
+++ b/schemas/0.15.0/fmu_results.json
@@ -4324,7 +4324,7 @@
         "table",
         "dictionary",
         "faultroom_triangulated",
-        "triangulated_surface"
+        "triangulated"
       ],
       "title": "Layout",
       "type": "string"
@@ -4997,7 +4997,6 @@
         "class": {
           "enum": [
             "surface",
-            "triangulated_surface",
             "table",
             "cpgrid",
             "cpgrid_property",

--- a/src/fmu/datamodels/fmu_results/enums.py
+++ b/src/fmu/datamodels/fmu_results/enums.py
@@ -79,7 +79,6 @@ class ObjectMetadataClass(MetadataClass):
     """The class of a data object (typically originating from an RMS model)."""
 
     surface = "surface"
-    triangulated_surface = "triangulated_surface"
     table = "table"
     cpgrid = "cpgrid"
     cpgrid_property = "cpgrid_property"
@@ -108,7 +107,7 @@ class Layout(StrEnum):
     table = "table"
     dictionary = "dictionary"
     faultroom_triangulated = "faultroom_triangulated"
-    triangulated_surface = "triangulated_surface"
+    triangulated = "triangulated"
 
 
 class FMUContext(str, Enum):

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -50,6 +50,9 @@ class FmuResultsSchema(SchemaBase):
     VERSION_CHANGELOG: str = """
     #### 0.15.0
 
+    - 'ObjectMetadataClass.triangulated_surface' is removed,
+      replaced by 'ObjectMetadataClass.surface'
+    - 'Layout.triangulated_surface' is renamed to 'Layout.triangulated'
 
     #### 0.14.0
 
@@ -314,7 +317,6 @@ class ObjectMetadata(MetadataBase):
 
     class_: Literal[
         ObjectMetadataClass.surface,
-        ObjectMetadataClass.triangulated_surface,
         ObjectMetadataClass.table,
         ObjectMetadataClass.cpgrid,
         ObjectMetadataClass.cpgrid_property,


### PR DESCRIPTION
Resolves #36 

1. `ObjectMetadataClass.triangulated_surface` is removed and replaced by `ObjectMetadataClass.surface`
2. `Layout.triangulated_surface` is renamed to `Layout.triangulated`

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅