### PR TITLE
ENH: Check schemas in staging same as other branches

### DIFF
--- a/.github/workflows/schemas-up-to-data.yml
+++ b/.github/workflows/schemas-up-to-data.yml
@@ -28,11 +28,7 @@ jobs:
 
       - name: Check schema
         run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "staging" ]]; then
-            ./tools/update-schemas.py --diff --prod
-          else
-            ./tools/update-schemas.py --diff
-          fi
+          ./tools/update-schemas.py --diff
 
       - name: Ensure schema validates with AJV
         run: |


### PR DESCRIPTION
Part of rolling out #40 

The schemas in the `staging` branch should now be checked the same ways as the schemas in the other branches when running the `schema-up-to-data.yml` workflow.

In #40 we changed the way schema urls are handled. From now on all schemas in all branches will point to dev in the code repo. The docker container setup (which is run when the Radix schema application is started) will take care of replacing the urls to `prod` if needed. 

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅