### PR TITLE
REL: Use dev urls for schemas in staging

### DIFF
--- a/.github/workflows/schemas-up-to-data.yml
+++ b/.github/workflows/schemas-up-to-data.yml
@@ -28,11 +28,7 @@ jobs:
 
       - name: Check schema
         run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "staging" ]]; then
-            ./tools/update-schemas.py --diff --prod
-          else
-            ./tools/update-schemas.py --diff
-          fi
+          ./tools/update-schemas.py --diff
 
       - name: Ensure schema validates with AJV
         run: |

--- a/schemas/0.10.0/fmu_results.json
+++ b/schemas/0.10.0/fmu_results.json
@@ -2675,7 +2675,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3480,7 +3480,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -7859,7 +7859,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
             "version": "0.1.0"
           }
         },
@@ -10638,7 +10638,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.10.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.10.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/0.11.0/fmu_results.json
+++ b/schemas/0.11.0/fmu_results.json
@@ -3032,7 +3032,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3805,7 +3805,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3907,7 +3907,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -8323,7 +8323,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
             "version": "0.1.0"
           }
         },
@@ -11173,7 +11173,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.11.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.11.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/0.12.0/fmu_results.json
+++ b/schemas/0.12.0/fmu_results.json
@@ -3033,7 +3033,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3806,7 +3806,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3908,7 +3908,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -8324,7 +8324,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
             "version": "0.1.0"
           }
         },
@@ -11174,7 +11174,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.12.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.12.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/0.13.0/fmu_results.json
+++ b/schemas/0.13.0/fmu_results.json
@@ -3033,7 +3033,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3806,7 +3806,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3908,7 +3908,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -8324,7 +8324,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
             "version": "0.1.0"
           }
         },
@@ -11174,7 +11174,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.13.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.13.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/0.14.0/fmu_results.json
+++ b/schemas/0.14.0/fmu_results.json
@@ -3036,7 +3036,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3809,7 +3809,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3911,7 +3911,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -8327,7 +8327,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
             "version": "0.1.0"
           }
         },
@@ -11203,7 +11203,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.14.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.14.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/0.15.0/fmu_results.json
+++ b/schemas/0.15.0/fmu_results.json
@@ -3036,7 +3036,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3809,7 +3809,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
             "version": "0.1.0"
           }
         },
@@ -3911,7 +3911,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -8326,7 +8326,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
             "version": "0.1.0"
           }
         },
@@ -11202,7 +11202,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.15.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.15.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/0.8.0/fmu_results.json
+++ b/schemas/0.8.0/fmu_results.json
@@ -3424,7 +3424,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -10777,7 +10777,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.8.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/0.9.0/fmu_results.json
+++ b/schemas/0.9.0/fmu_results.json
@@ -3290,7 +3290,7 @@
         "file_schema": {
           "$ref": "#/$defs/FileSchema",
           "default": {
-            "url": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
             "version": "0.1.0"
           }
         },
@@ -10287,7 +10287,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/0.9.0/fmu_results.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.9.0/fmu_results.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "discriminator": {
     "propertyName": "class"

--- a/schemas/file_formats/0.1.0/field_outline.json
+++ b/schemas/file_formats/0.1.0/field_outline.json
@@ -31,7 +31,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Represents the resultant field outline parquet file, which is\nnaturally a list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
   "items": {

--- a/schemas/file_formats/0.1.0/fluid_contact_outline.json
+++ b/schemas/file_formats/0.1.0/fluid_contact_outline.json
@@ -31,7 +31,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Represents the resultant fluid contact outline parquet file, which is\nnaturally a list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
   "items": {

--- a/schemas/file_formats/0.1.0/inplace_volumes.json
+++ b/schemas/file_formats/0.1.0/inplace_volumes.json
@@ -141,7 +141,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Represents the resultant static inplace volumes parquet file, which is naturally\na list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
   "items": {

--- a/schemas/file_formats/0.1.0/structure_depth_fault_lines.json
+++ b/schemas/file_formats/0.1.0/structure_depth_fault_lines.json
@@ -36,7 +36,7 @@
       "type": "object"
     }
   },
-  "$id": "https://main-fmu-schemas-prod.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Represents the resultant structure depth fault lines parquet file, which is\nnaturally a list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
   "items": {


### PR DESCRIPTION
Part of releasing #40 

Set all schema urls in the staging branch to point to dev.

From now on all schemas in all branches will point to dev in the code repo. The docker container setup (which is run when the Radix schema application is started) will take care of replacing the urls with prod urls when the app is run in the `staging` and `prod` Radix environment. 