### PR TITLE
CI: Run prepare schema release from publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pypi-publish:
     name: Upload release to PyPI


### PR DESCRIPTION
Run `prepare_schema_release` workflow as final part of `publish` workflow.

When a new release is published on github, the pipeline `publish.yml` will be automatically run. This pipeline publishes the new release to PyPi. If the publish to PyPi completes successfully, a new job `prepare-schema-release` will now be run that kicks of the `prepare-schema-release` workflow. This workflow will create a PR towards `staging` with the changes that should go into the new schema release. 

## Checklist

- [ ] Tests added (if not, comment why): N/A as only workflow changes are made
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`): N/A
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅