### PR TITLE
Remove faultroom_triangulated enumeration

### DIFF
--- a/src/fmu/datamodels/fmu_results/enums.py
+++ b/src/fmu/datamodels/fmu_results/enums.py
@@ -338,7 +338,6 @@ class Layout(StrEnum):
     cornerpoint = "cornerpoint"
     table = "table"
     dictionary = "dictionary"
-    faultroom_triangulated = "faultroom_triangulated"
     triangulated = "triangulated"
 
 


### PR DESCRIPTION
Resolves #37 

Removes the enumeration `faultroom_triangulated`

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅