### PR TITLE
CLN: Group shared models into fmu/datamodels/common directory

### DIFF
--- a/src/fmu/datamodels/common/__init__.py
+++ b/src/fmu/datamodels/common/__init__.py
@@ -1,0 +1,38 @@
+from .access import Access, Asset, Ssdl, SsdlAccess
+from .masterdata import (
+    CoordinateSystem,
+    CountryItem,
+    DiscoveryItem,
+    FieldItem,
+    Masterdata,
+    Smda,
+    StratigraphicColumn,
+)
+from .tracklog import (
+    OperatingSystem,
+    SystemInformation,
+    Tracklog,
+    TracklogEvent,
+    User,
+    Version,
+)
+
+__all__ = [
+    "Access",
+    "SsdlAccess",
+    "Asset",
+    "Ssdl",
+    "Masterdata",
+    "Smda",
+    "StratigraphicColumn",
+    "CoordinateSystem",
+    "CountryItem",
+    "FieldItem",
+    "DiscoveryItem",
+    "Tracklog",
+    "OperatingSystem",
+    "SystemInformation",
+    "TracklogEvent",
+    "User",
+    "Version",
+]

--- a/src/fmu/datamodels/common/access.py
+++ b/src/fmu/datamodels/common/access.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+from . import enums
+
+
+class Access(BaseModel):
+    """
+    The ``access`` block contains information related to access control for
+    this data object.
+    """
+
+    asset: Asset
+    """A block containing information about the owner asset of these data.
+    See :class:`Asset`."""
+
+    classification: enums.Classification | None = Field(default=None)
+    """The access classification level. See :class:`enums.Classification`."""
+
+
+class SsdlAccess(Access):
+    """
+    The ``access`` block contains information related to access control for
+    this data object, with legacy SSDL settings.
+    """
+
+    ssdl: Ssdl
+    """A block containing information related to SSDL. See :class:`Ssdl`."""
+
+
+class Asset(BaseModel):
+    """The ``access.asset`` block contains information about the owner asset of
+    these data."""
+
+    name: str = Field(examples=["Drogon"])
+    """A string referring to a known asset name."""
+
+
+class Ssdl(BaseModel):
+    """
+    The ``access.ssdl`` block contains information related to SSDL.
+    Note that this is kept due to legacy.
+    """
+
+    access_level: enums.Classification
+    """The SSDL access level. See :class:`Classification`."""
+
+    rep_include: bool
+    """Flag if this data is to be shown in REP or not."""

--- a/src/fmu/datamodels/common/enums.py
+++ b/src/fmu/datamodels/common/enums.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Classification(StrEnum):
+    """The security classification for a given data object."""
+
+    asset = "asset"
+    # Deprecated. This value should be undocumented and eventually removed.
+
+    internal = "internal"
+    """Grants access to all users with ``READ`` access to the asset.
+
+    The ``READ`` role is an access role defined by the asset's Unix and Sumo groups.
+    This is the default for most data.
+    """
+
+    restricted = "restricted"
+    """Grants access to all users with ``WRITE`` access to the asset.
+
+    The ``WRITE`` role is an access role defined by the asset's Unix and Sumo groups.
+    This is the default for some sensitive data, like volumes, but in general must be
+    explicitly set when restricted access is desired.
+    """
+
+
+class TrackLogEventType(StrEnum):
+    """The type of event being logged"""
+
+    created = "created"
+    """The initial data was created."""
+
+    updated = "updated"
+    """Data was updated."""
+
+    merged = "merged"
+    """Data was merged."""

--- a/src/fmu/datamodels/common/masterdata.py
+++ b/src/fmu/datamodels/common/masterdata.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+
+class Masterdata(BaseModel):
+    """The ``masterdata`` block contains information related to masterdata.
+    Currently, SMDA holds the masterdata.
+    """
+
+    smda: Smda
+    """Block containing SMDA-related attributes. See :class:`Smda`."""
+
+
+class Smda(BaseModel):
+    """The ``masterdata.smda`` block contains SMDA-related attributes."""
+
+    coordinate_system: CoordinateSystem
+    """Reference to coordinate system known to SMDA.
+    See :class:`CoordinateSystem`."""
+
+    country: list[CountryItem]
+    """A list referring to countries known to SMDA. First item is primary.
+    See :class:`CountryItem`."""
+
+    discovery: list[DiscoveryItem]
+    """A list referring to discoveries known to SMDA. First item is primary.
+    See :class:`DiscoveryItem`."""
+
+    field: list[FieldItem]
+    """A list referring to fields known to SMDA. First item is primary.
+    See :class:`FieldItem`."""
+
+    stratigraphic_column: StratigraphicColumn
+    """Reference to stratigraphic column known to SMDA.
+    See :class:`StratigraphicColumn`."""
+
+
+class CountryItem(BaseModel):
+    """A single country in the ``smda.masterdata.country`` list of countries
+    known to SMDA."""
+
+    identifier: str = Field(examples=["Norway"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class DiscoveryItem(BaseModel):
+    """A single discovery in the ``masterdata.smda.discovery`` list of discoveries
+    known to SMDA."""
+
+    short_identifier: str = Field(examples=["SomeDiscovery"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class FieldItem(BaseModel):
+    """A single field in the ``masterdata.smda.field`` list of fields
+    known to SMDA."""
+
+    identifier: str = Field(examples=["OseFax"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class CoordinateSystem(BaseModel):
+    """The ``masterdata.smda.coordinate_system`` block contains the coordinate
+    system known to SMDA."""
+
+    identifier: str = Field(examples=["ST_WGS84_UTM37N_P32637"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""
+
+
+class StratigraphicColumn(BaseModel):
+    """The ``masterdata.smda.stratigraphic_column`` block contains the
+    stratigraphic column known to SMDA."""
+
+    identifier: str = Field(examples=["DROGON_2020"])
+    """Identifier known to SMDA."""
+
+    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
+    """Identifier known to SMDA."""

--- a/src/fmu/datamodels/common/tracklog.py
+++ b/src/fmu/datamodels/common/tracklog.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import datetime
+import getpass
+import os
+import platform
+from typing import (
+    Any,
+)
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    Field,
+    RootModel,
+)
+
+from . import enums
+
+
+class User(BaseModel):
+    """The ``user`` block holds information about the user."""
+
+    id: str = Field(examples=["peesv", "jriv"])
+    """A user identity reference."""
+
+
+class Version(BaseModel):
+    """
+    A generic block that contains a string representing the version of
+    something.
+    """
+
+    version: str
+    """A string representing the version."""
+
+
+class Tracklog(RootModel):
+    """The ``tracklog`` block contains a record of events recorded on these data.
+    This data object describes the list of tracklog events, in addition to functionality
+    for constructing a tracklog and adding new records to it.
+    """
+
+    root: list[TracklogEvent]
+
+    def __getitem__(self, item: int) -> TracklogEvent:
+        return self.root[item]
+
+    def __iter__(
+        self,
+    ) -> Any:
+        # Using ´Any´ as return type here as mypy is having issues
+        # resolving the correct type
+        return iter(self.root)
+
+    @classmethod
+    def initialize(cls, fmu_dataio_version: str) -> Tracklog:
+        """Initialize the tracklog object with a list containing one
+        TracklogEvent of type 'created'"""
+
+        return cls(
+            root=[
+                cls._generate_tracklog_event(
+                    enums.TrackLogEventType.created, fmu_dataio_version
+                )
+            ]
+        )
+
+    def append(self, event: enums.TrackLogEventType, fmu_dataio_version: str) -> None:
+        """Append new tracklog record to the tracklog."""
+        self.root.append(self._generate_tracklog_event(event, fmu_dataio_version))
+
+    @staticmethod
+    def _generate_tracklog_event(
+        event: enums.TrackLogEventType, fmu_dataio_version: str
+    ) -> TracklogEvent:
+        """Generate new tracklog event with the given event type"""
+        komodo_release = os.environ.get(
+            "KOMODO_RELEASE", os.environ.get("KOMODO_RELEASE_BACKUP", None)
+        )
+        komodo = (
+            Version.model_construct(version=komodo_release) if komodo_release else None
+        )
+        fmu_dataio = Version.model_construct(version=fmu_dataio_version)
+        return TracklogEvent.model_construct(
+            datetime=datetime.datetime.now(datetime.UTC),
+            event=event,
+            user=User.model_construct(id=getpass.getuser()),
+            sysinfo=(
+                SystemInformation.model_construct(
+                    fmu_dataio=fmu_dataio,
+                    komodo=komodo,
+                    operating_system=(
+                        OperatingSystem.model_construct(
+                            hostname=platform.node(),
+                            operating_system=platform.platform(),
+                            release=platform.release(),
+                            system=platform.system(),
+                            version=platform.version(),
+                        )
+                    ),
+                )
+            ),
+        )
+
+
+class OperatingSystem(BaseModel):
+    """
+    The ``operating_system`` block contains information about the OS on which the
+    ensemble was run.
+    """
+
+    hostname: str = Field(examples=["st-123.equinor.com"])
+    """A string containing the network name of the machine."""
+
+    operating_system: str = Field(examples=["Darwin-18.7.0-x86_64-i386-64bit"])
+    """A string containing the name of the operating system implementation."""
+
+    release: str = Field(examples=["18.7.0"])
+    """A string containing the level of the operating system."""
+
+    system: str = Field(examples=["GNU/Linux"])
+    """A string containing the name of the operating system kernel."""
+
+    version: str = Field(examples=["#1 SMP Tue Aug 27 21:37:59 PDT 2019"])
+    """The specific release version of the system."""
+
+
+# TODO: Make `fmu_dataio` and `operating_system` non-optional
+#  when fmu-sumo-aggregation-service uses only fmu-dataio
+class SystemInformation(BaseModel):
+    """
+    The ``tracklog.sysinfo`` block contains information about the system upon which
+    these data were exported from.
+    """
+
+    fmu_dataio: Version | None = Field(
+        alias="fmu-dataio",
+        default=None,
+        examples=["1.2.3"],
+    )
+    """The version of fmu-dataio used to export the data. See :class:`Version`."""
+
+    komodo: Version | None = Field(
+        default=None,
+        examples=["2023.12.05-py38"],
+    )
+    """The version of Komodo in which the the ensemble was run from."""
+
+    operating_system: OperatingSystem | None = Field(default=None)
+    """The operating system from which the ensemble was started from.
+    See :class:`OperatingSystem`."""
+
+
+class TracklogEvent(BaseModel):
+    """The ``tracklog`` block contains a record of events recorded on these data.
+    This data object describes a tracklog event.
+    """
+
+    datetime: AwareDatetime = Field(examples=["2020-10-28T14:28:024286Z"])
+    """A datetime representation recording when the event occurred."""
+
+    event: enums.TrackLogEventType
+    """The type of event being logged.
+    See :class:`datamodels.common.enums.TrackLogEventType`.
+    """
+
+    user: User
+    """The user who caused the event to happen. See :class:`User`."""
+
+    # TODO: Make non-optional when fmu-sumo-aggregation-service uses only fmu-dataio
+    sysinfo: SystemInformation | None = Field(
+        default_factory=SystemInformation,
+    )
+    """Information about the system on which the event occurred.
+    See :class:`SystemInformation`."""

--- a/src/fmu/datamodels/fmu_results/enums.py
+++ b/src/fmu/datamodels/fmu_results/enums.py
@@ -3,28 +3,6 @@ from __future__ import annotations
 from enum import Enum, IntEnum, StrEnum
 
 
-class Classification(StrEnum):
-    """The security classification for a given data object."""
-
-    asset = "asset"
-    # Deprecated. This value should be undocumented and eventually removed.
-
-    internal = "internal"
-    """Grants access to all users with ``READ`` access to the asset.
-
-    The ``READ`` role is an access role defined by the asset's Unix and Sumo groups.
-    This is the default for most data.
-    """
-
-    restricted = "restricted"
-    """Grants access to all users with ``WRITE`` access to the asset.
-
-    The ``WRITE`` role is an access role defined by the asset's Unix and Sumo groups.
-    This is the default for some sensitive data, like volumes, but in general must be
-    explicitly set when restricted access is desired.
-    """
-
-
 class AxisOrientation(IntEnum):
     """The axis orientation for a given data object."""
 
@@ -368,19 +346,6 @@ class DomainReference(StrEnum):
 
     rkb = "rkb"
     """In reference to Rotary Kelly Bushing (RKB)."""
-
-
-class TrackLogEventType(StrEnum):
-    """The type of event being logged"""
-
-    created = "created"
-    """The initial data was created."""
-
-    updated = "updated"
-    """Data was updated."""
-
-    merged = "merged"
-    """Data was merged."""
 
 
 class FluidContactType(StrEnum):

--- a/src/fmu/datamodels/fmu_results/fields.py
+++ b/src/fmu/datamodels/fmu_results/fields.py
@@ -1,77 +1,26 @@
 from __future__ import annotations
 
-import datetime
-import getpass
-import os
-import platform
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Any,
     Literal,
 )
 from uuid import UUID
 
 from pydantic import (
-    AwareDatetime,
     BaseModel,
     Field,
     GetJsonSchemaHandler,
-    RootModel,
     model_validator,
 )
 
+from fmu.datamodels.common.tracklog import User
 from fmu.datamodels.types import MD5HashStr
 
 from . import enums
 
 if TYPE_CHECKING:
     from pydantic_core import CoreSchema
-
-
-class Asset(BaseModel):
-    """The ``access.asset`` block contains information about the owner asset of
-    these data."""
-
-    name: str = Field(examples=["Drogon"])
-    """A string referring to a known asset name."""
-
-
-class Ssdl(BaseModel):
-    """
-    The ``access.ssdl`` block contains information related to SSDL.
-    Note that this is kept due to legacy.
-    """
-
-    access_level: enums.Classification
-    """The SSDL access level. See :class:`enums.Classification`."""
-
-    rep_include: bool
-    """Flag if this data is to be shown in REP or not."""
-
-
-class Access(BaseModel):
-    """
-    The ``access`` block contains information related to access control for
-    this data object.
-    """
-
-    asset: Asset
-    """A block containing information about the owner asset of these data.
-    See :class:`Asset`."""
-
-    classification: enums.Classification | None = Field(default=None)
-    """The access classification level. See :class:`enums.Classification`."""
-
-
-class SsdlAccess(Access):
-    """
-    The ``access`` block contains information related to access control for
-    this data object, with legacy SSDL settings.
-    """
-
-    ssdl: Ssdl
-    """A block containing information related to SSDL. See :class:`Ssdl`."""
 
 
 class File(BaseModel):
@@ -152,13 +101,6 @@ class Workflow(BaseModel):
 
     reference: str
     """A string referring to which workflow this data object was exported by."""
-
-
-class User(BaseModel):
-    """The ``user`` block holds information about the user."""
-
-    id: str = Field(examples=["peesv", "jriv"])
-    """A user identity reference."""
 
 
 class Case(BaseModel):
@@ -284,243 +226,6 @@ class Realization(BaseModel):
         Please note that users shall not set this flag in the metadata upon export;
         it is intended to be configured through interactions with the Sumo GUI.
     """
-
-
-class CountryItem(BaseModel):
-    """A single country in the ``smda.masterdata.country`` list of countries
-    known to SMDA."""
-
-    identifier: str = Field(examples=["Norway"])
-    """Identifier known to SMDA."""
-
-    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
-    """Identifier known to SMDA."""
-
-
-class DiscoveryItem(BaseModel):
-    """A single discovery in the ``masterdata.smda.discovery`` list of discoveries
-    known to SMDA."""
-
-    short_identifier: str = Field(examples=["SomeDiscovery"])
-    """Identifier known to SMDA."""
-
-    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
-    """Identifier known to SMDA."""
-
-
-class FieldItem(BaseModel):
-    """A single field in the ``masterdata.smda.field`` list of fields
-    known to SMDA."""
-
-    identifier: str = Field(examples=["OseFax"])
-    """Identifier known to SMDA."""
-
-    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
-    """Identifier known to SMDA."""
-
-
-class CoordinateSystem(BaseModel):
-    """The ``masterdata.smda.coordinate_system`` block contains the coordinate
-    system known to SMDA."""
-
-    identifier: str = Field(examples=["ST_WGS84_UTM37N_P32637"])
-    """Identifier known to SMDA."""
-
-    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
-    """Identifier known to SMDA."""
-
-
-class StratigraphicColumn(BaseModel):
-    """The ``masterdata.smda.stratigraphic_column`` block contains the
-    stratigraphic column known to SMDA."""
-
-    identifier: str = Field(examples=["DROGON_2020"])
-    """Identifier known to SMDA."""
-
-    uuid: UUID = Field(examples=["15ce3b84-766f-4c93-9050-b154861f9100"])
-    """Identifier known to SMDA."""
-
-
-class Smda(BaseModel):
-    """The ``masterdata.smda`` block contains SMDA-related attributes."""
-
-    coordinate_system: CoordinateSystem
-    """Reference to coordinate system known to SMDA.
-    See :class:`CoordinateSystem`."""
-
-    country: list[CountryItem]
-    """A list referring to countries known to SMDA. First item is primary.
-    See :class:`CountryItem`."""
-
-    discovery: list[DiscoveryItem]
-    """A list referring to discoveries known to SMDA. First item is primary.
-    See :class:`DiscoveryItem`."""
-
-    field: list[FieldItem]
-    """A list referring to fields known to SMDA. First item is primary.
-    See :class:`FieldItem`."""
-
-    stratigraphic_column: StratigraphicColumn
-    """Reference to stratigraphic column known to SMDA.
-    See :class:`StratigraphicColumn`."""
-
-
-class Masterdata(BaseModel):
-    """The ``masterdata`` block contains information related to masterdata.
-    Currently, SMDA holds the masterdata.
-    """
-
-    smda: Smda
-    """Block containing SMDA-related attributes. See :class:`Smda`."""
-
-
-class Version(BaseModel):
-    """
-    A generic block that contains a string representing the version of
-    something.
-    """
-
-    version: str
-    """A string representing the version."""
-
-
-class OperatingSystem(BaseModel):
-    """
-    The ``operating_system`` block contains information about the OS on which the
-    ensemble was run.
-    """
-
-    hostname: str = Field(examples=["st-123.equinor.com"])
-    """A string containing the network name of the machine."""
-
-    operating_system: str = Field(examples=["Darwin-18.7.0-x86_64-i386-64bit"])
-    """A string containing the name of the operating system implementation."""
-
-    release: str = Field(examples=["18.7.0"])
-    """A string containing the level of the operating system."""
-
-    system: str = Field(examples=["GNU/Linux"])
-    """A string containing the name of the operating system kernel."""
-
-    version: str = Field(examples=["#1 SMP Tue Aug 27 21:37:59 PDT 2019"])
-    """The specific release version of the system."""
-
-
-# TODO: Make `fmu_dataio` and `operating_system` non-optional
-#  when fmu-sumo-aggregation-service uses only fmu-dataio
-class SystemInformation(BaseModel):
-    """
-    The ``tracklog.sysinfo`` block contains information about the system upon which
-    these data were exported from.
-    """
-
-    fmu_dataio: Version | None = Field(
-        alias="fmu-dataio",
-        default=None,
-        examples=["1.2.3"],
-    )
-    """The version of fmu-dataio used to export the data. See :class:`Version`."""
-
-    komodo: Version | None = Field(
-        default=None,
-        examples=["2023.12.05-py38"],
-    )
-    """The version of Komodo in which the the ensemble was run from."""
-
-    operating_system: OperatingSystem | None = Field(default=None)
-    """The operating system from which the ensemble was started from.
-    See :class:`OperatingSystem`."""
-
-
-class Tracklog(RootModel):
-    """The ``tracklog`` block contains a record of events recorded on these data.
-    This data object describes the list of tracklog events, in addition to functionality
-    for constructing a tracklog and adding new records to it.
-    """
-
-    root: list[TracklogEvent]
-
-    def __getitem__(self, item: int) -> TracklogEvent:
-        return self.root[item]
-
-    def __iter__(
-        self,
-    ) -> Any:
-        # Using ´Any´ as return type here as mypy is having issues
-        # resolving the correct type
-        return iter(self.root)
-
-    @classmethod
-    def initialize(cls, fmu_dataio_version: str) -> Tracklog:
-        """Initialize the tracklog object with a list containing one
-        TracklogEvent of type 'created'"""
-
-        return cls(
-            root=[
-                cls._generate_tracklog_event(
-                    enums.TrackLogEventType.created, fmu_dataio_version
-                )
-            ]
-        )
-
-    def append(self, event: enums.TrackLogEventType, fmu_dataio_version: str) -> None:
-        """Append new tracklog record to the tracklog."""
-        self.root.append(self._generate_tracklog_event(event, fmu_dataio_version))
-
-    @staticmethod
-    def _generate_tracklog_event(
-        event: enums.TrackLogEventType, fmu_dataio_version: str
-    ) -> TracklogEvent:
-        """Generate new tracklog event with the given event type"""
-        komodo_release = os.environ.get(
-            "KOMODO_RELEASE", os.environ.get("KOMODO_RELEASE_BACKUP", None)
-        )
-        komodo = (
-            Version.model_construct(version=komodo_release) if komodo_release else None
-        )
-        fmu_dataio = Version.model_construct(version=fmu_dataio_version)
-        return TracklogEvent.model_construct(
-            datetime=datetime.datetime.now(datetime.UTC),
-            event=event,
-            user=User.model_construct(id=getpass.getuser()),
-            sysinfo=(
-                SystemInformation.model_construct(
-                    fmu_dataio=fmu_dataio,
-                    komodo=komodo,
-                    operating_system=(
-                        OperatingSystem.model_construct(
-                            hostname=platform.node(),
-                            operating_system=platform.platform(),
-                            release=platform.release(),
-                            system=platform.system(),
-                            version=platform.version(),
-                        )
-                    ),
-                )
-            ),
-        )
-
-
-class TracklogEvent(BaseModel):
-    """The ``tracklog`` block contains a record of events recorded on these data.
-    This data object describes a tracklog event.
-    """
-
-    datetime: AwareDatetime = Field(examples=["2020-10-28T14:28:024286Z"])
-    """A datetime representation recording when the event occurred."""
-
-    event: enums.TrackLogEventType
-    """The type of event being logged. See :class:`enums.TrackLogEventType`."""
-
-    user: User
-    """The user who caused the event to happen. See :class:`User`."""
-
-    # TODO: Make non-optional when fmu-sumo-aggregation-service uses only fmu-dataio
-    sysinfo: SystemInformation | None = Field(
-        default_factory=SystemInformation,
-    )
-    """Information about the system on which the event occurred.
-    See :class:`SystemInformation`."""
 
 
 class Display(BaseModel):

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -17,22 +17,21 @@ from fmu.datamodels._schema_base import (
     GenerateJsonSchemaBase,
     SchemaBase,
 )
+from fmu.datamodels.common.access import Access, SsdlAccess
+from fmu.datamodels.common.masterdata import Masterdata
+from fmu.datamodels.common.tracklog import Tracklog
 from fmu.datamodels.types import VersionStr
 
 from .data import AnyData
 from .enums import FMUResultsMetadataClass, MetadataClass, ObjectMetadataClass
 from .fields import (
     FMU,
-    Access,
     Display,
     File,
     FMUBase,
     FMUEnsemble,
     FMUIteration,
     FMURealization,
-    Masterdata,
-    SsdlAccess,
-    Tracklog,
 )
 
 if TYPE_CHECKING:

--- a/src/fmu/datamodels/fmu_results/global_configuration.py
+++ b/src/fmu/datamodels/fmu_results/global_configuration.py
@@ -18,7 +18,11 @@ from pydantic import (
     model_validator,
 )
 
-from . import data, enums, fields
+from fmu.datamodels.common.access import Asset
+from fmu.datamodels.common.enums import Classification
+from fmu.datamodels.common.masterdata import Masterdata
+
+from . import data, fields
 
 
 def validation_error_warning(err: ValidationError) -> None:
@@ -44,7 +48,7 @@ class Ssdl(BaseModel):
     Defines the configuration for the SSDL.
     """
 
-    access_level: enums.Classification | None = Field(default=None)
+    access_level: Classification | None = Field(default=None)
     rep_include: bool | None = Field(default=None)
 
 
@@ -53,9 +57,9 @@ class Access(BaseModel, use_enum_values=True):
     Manages access configurations, combining asset and SSDL information.
     """
 
-    asset: fields.Asset
+    asset: Asset
     ssdl: Ssdl | None = Field(default=None)
-    classification: enums.Classification | None = Field(default=None)
+    classification: Classification | None = Field(default=None)
 
     @model_validator(mode="after")
     def _validate_classification_ssdl_access_level(self) -> Access:
@@ -144,6 +148,6 @@ class GlobalConfiguration(BaseModel):
     """
 
     access: Access
-    masterdata: fields.Masterdata
+    masterdata: Masterdata
     model: fields.Model
     stratigraphy: Stratigraphy | None = Field(default=None)

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -4,6 +4,30 @@ from uuid import UUID
 import pytest
 from pydantic import BaseModel
 
+from fmu.datamodels.common.access import (
+    Access,
+    Asset,
+    Ssdl,
+    SsdlAccess,
+)
+from fmu.datamodels.common.enums import Classification, TrackLogEventType
+from fmu.datamodels.common.masterdata import (
+    CoordinateSystem,
+    CountryItem,
+    DiscoveryItem,
+    FieldItem,
+    Masterdata,
+    Smda,
+    StratigraphicColumn,
+)
+from fmu.datamodels.common.tracklog import (
+    OperatingSystem,
+    SystemInformation,
+    Tracklog,
+    TracklogEvent,
+    User,
+    Version,
+)
 from fmu.datamodels.fmu_results import enums
 from fmu.datamodels.fmu_results.data import (
     AnyData,
@@ -19,29 +43,12 @@ from fmu.datamodels.fmu_results.data import (
 )
 from fmu.datamodels.fmu_results.fields import (
     FMU,
-    Access,
-    Asset,
     Case,
     Context,
-    CoordinateSystem,
-    CountryItem,
-    DiscoveryItem,
     Display,
-    FieldItem,
     File,
     FMUBase,
-    Masterdata,
     Model,
-    OperatingSystem,
-    Smda,
-    Ssdl,
-    SsdlAccess,
-    StratigraphicColumn,
-    SystemInformation,
-    Tracklog,
-    TracklogEvent,
-    User,
-    Version,
 )
 from fmu.datamodels.fmu_results.fmu_results import (
     CaseMetadata,
@@ -132,7 +139,7 @@ def _generate_metadata_base() -> dict:
         [
             TracklogEvent.model_construct(
                 datetime=datetime.datetime.now(datetime.UTC),
-                event=enums.TrackLogEventType.created,
+                event=TrackLogEventType.created,
                 user=User(id="user"),
                 sysinfo=SystemInformation.model_construct(
                     fmu_dataio=Version.model_construct(version="dummy_version"),
@@ -197,7 +204,7 @@ def _generate_object_metadata_base() -> dict:
     access = SsdlAccess.model_construct(
         asset=Asset(name="test"),
         ssdl=Ssdl.model_construct(
-            access_level=enums.Classification.internal, rep_include=False
+            access_level=Classification.internal, rep_include=False
         ),
     )
 
@@ -228,7 +235,7 @@ def case_metadata() -> dict:
     fmu_base = _generate_fmu_base()
 
     access = Access.model_construct(
-        asset=Asset(name="test"), classification=enums.Classification.internal
+        asset=Asset(name="test"), classification=Classification.internal
     )
 
     case_metadata_dict = {

--- a/tests/test_models/test_fields.py
+++ b/tests/test_models/test_fields.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 from fmu.datamodels import FmuResults
-from fmu.datamodels.fmu_results import enums
+from fmu.datamodels.common.enums import Classification
 from fmu.datamodels.fmu_results.fields import Aggregation, Realization
 
 
@@ -176,7 +176,7 @@ def test_aggregation_and_realalization_field(fluid_contact_metadata: dict) -> No
         FmuResults.model_validate(fluid_contact_metadata)
 
 
-@pytest.mark.parametrize("classification", enums.Classification)
+@pytest.mark.parametrize("classification", Classification)
 def test_access_field(
     case_metadata: dict, seismic_metadata: dict, classification: dict
 ) -> None:


### PR DESCRIPTION
Resolves #87 (NB: will also need to update fmu-dataio accordingly, and check fmu-settings, fmu-settings-cli and fmu-settings-api)

Grouped all shared models into a separate directory, since these will be denormalized into all metadata produced. This is pre-work for creating an FMU Context model/schema.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅