### PR TITLE
FIX: Add string as valid dtype for parameters

### DIFF
--- a/src/fmu/datamodels/parameters/table_schema.py
+++ b/src/fmu/datamodels/parameters/table_schema.py
@@ -6,9 +6,11 @@ from .metadata import ParameterMetadata
 
 
 class ParameterColumn(BaseModel):
-    """Metadata for a parameter column."""
+    """Metadata for a parameter column.
 
-    type: Literal["float64", "int64"]
+    'string' is a valid dtype when it comes from the design matrix."""
+
+    type: Literal["float64", "int64", "string"]
     metadata: ParameterMetadata
 
 


### PR DESCRIPTION
Add string as valid dtype for parameters

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅