### PR TITLE
FIX: Use 'REAL' realization column in parameters

### DIFF
--- a/schemas/file_formats/0.1.0/ert_parameters.json
+++ b/schemas/file_formats/0.1.0/ert_parameters.json
@@ -233,6 +233,7 @@
           "enum": [
             "float64",
             "int64",
+            "int32",
             "string"
           ],
           "title": "Type",
@@ -537,7 +538,7 @@
   "additionalProperties": {
     "$ref": "#/$defs/ErtParameterColumn"
   },
-  "description": "Represents the Ert parameters exported as a Parquet file.\n\nEvery parameter column has associated column metadata.\n\nThe table always has a 'realization' column (int64) as the first column. That column\nis not represented in this schema, but is implied.",
+  "description": "Represents the Ert parameters exported as a Parquet file.\n\nEvery parameter column has associated column metadata.\n\nThe table always has a 'REAL' column (int64) as the first column. That column\nis not represented in this schema, but is implied.",
   "title": "ErtParametersResult",
   "type": "object",
   "version": "0.1.0"

--- a/src/fmu/datamodels/standard_results/ert_parameters.py
+++ b/src/fmu/datamodels/standard_results/ert_parameters.py
@@ -188,7 +188,7 @@ class ErtParameterColumn(BaseModel):
 
     'string' is a valid dtype when it comes from the design matrix."""
 
-    type: Literal["float64", "int64", "string"]
+    type: Literal["float64", "int64", "int32", "string"]
     metadata: ErtParameterMetadata
 
 
@@ -198,12 +198,12 @@ class ErtParametersResult(RootModel[dict[str, ErtParameterColumn]]):
 
     Every parameter column has associated column metadata.
 
-    The table always has a 'realization' column (int64) as the first column. That column
+    The table always has a 'REAL' column (int64) as the first column. That column
     is not represented in this schema, but is implied.
     """
 
     def all_column_names(self) -> list[str]:
-        return ["realization", *self.root.keys()]
+        return ["REAL", *self.root.keys()]
 
 
 class ErtParametersSchema(SchemaBase):


### PR DESCRIPTION
Resolves #139

Overwriting the schema because it will not have actually been used yet, and is a one word change.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅