### PR TITLE
ENH: Add codenames for discrete grid properties

### DIFF
--- a/schemas/0.19.0/fmu_results.json
+++ b/schemas/0.19.0/fmu_results.json
@@ -1,0 +1,12283 @@
+{
+  "$contractual": [
+    "access",
+    "class",
+    "data.alias",
+    "data.bbox",
+    "data.content",
+    "data.fluid_contact.contact",
+    "data.format",
+    "data.geometry",
+    "data.grid_model",
+    "data.is_observation",
+    "data.is_prediction",
+    "data.name",
+    "data.offset",
+    "data.seismic.attribute",
+    "data.spec.columns",
+    "data.standard_result.name",
+    "data.stratigraphic",
+    "data.tagname",
+    "data.time",
+    "data.vertical_domain",
+    "file.checksum_md5",
+    "file.relative_path",
+    "file.size_bytes",
+    "fmu.aggregation.operation",
+    "fmu.aggregation.realization_ids",
+    "fmu.case",
+    "fmu.context.stage",
+    "fmu.entity.uuid",
+    "fmu.ensemble.name",
+    "fmu.ensemble.uuid",
+    "fmu.ert.experiment.id",
+    "fmu.iteration.name",
+    "fmu.iteration.uuid",
+    "fmu.model",
+    "fmu.realization.id",
+    "fmu.realization.is_reference",
+    "fmu.realization.name",
+    "fmu.realization.uuid",
+    "fmu.workflow",
+    "masterdata",
+    "source",
+    "tracklog.datetime",
+    "tracklog.event",
+    "tracklog.user.id",
+    "version"
+  ],
+  "$defs": {
+    "Access": {
+      "description": "The ``access`` block contains information related to access control for\nthis data object.",
+      "properties": {
+        "asset": {
+          "$ref": "#/$defs/Asset"
+        },
+        "classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Classification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "asset"
+      ],
+      "title": "Access",
+      "type": "object"
+    },
+    "Aggregation": {
+      "description": "The ``fmu.aggregation`` block contains information about an aggregation\nperformed over an ensemble.",
+      "properties": {
+        "id": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Id",
+          "type": "string"
+        },
+        "operation": {
+          "title": "Operation",
+          "type": "string"
+        },
+        "realization_ids": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Realization Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "operation",
+        "realization_ids"
+      ],
+      "title": "Aggregation",
+      "type": "object"
+    },
+    "AnyData": {
+      "dependencies": {
+        "base": {
+          "required": [
+            "top"
+          ]
+        },
+        "top": {
+          "required": [
+            "base"
+          ]
+        }
+      },
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class, ``AnyData``, is a root model that allows for data with more specific\ncontent types to be placed within it. It can contain the metadata for any data\nobject.\n\nSee :class:`Data` to get an overview of all of the subfields used in the ``data``\nblock. Between the different content types, only the ``data.content`` field will\ndiffer. This field indicates the type of content the data are representing.",
+      "discriminator": {
+        "propertyName": "content"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/DepthData"
+        },
+        {
+          "$ref": "#/$defs/FaciesThicknessData"
+        },
+        {
+          "$ref": "#/$defs/FaultSurfaceData"
+        },
+        {
+          "$ref": "#/$defs/FaultLinesData"
+        },
+        {
+          "$ref": "#/$defs/FieldOutlineData"
+        },
+        {
+          "$ref": "#/$defs/FieldRegionData"
+        },
+        {
+          "$ref": "#/$defs/FluidContactData"
+        },
+        {
+          "$ref": "#/$defs/KPProductData"
+        },
+        {
+          "$ref": "#/$defs/LiftCurvesData"
+        },
+        {
+          "$ref": "#/$defs/NamedAreaData"
+        },
+        {
+          "$ref": "#/$defs/ParametersData"
+        },
+        {
+          "$ref": "#/$defs/PinchoutData"
+        },
+        {
+          "$ref": "#/$defs/ProductionNetworkData"
+        },
+        {
+          "$ref": "#/$defs/PropertyData"
+        },
+        {
+          "$ref": "#/$defs/FaultPropertiesData"
+        },
+        {
+          "$ref": "#/$defs/PVTData"
+        },
+        {
+          "$ref": "#/$defs/RegionsData"
+        },
+        {
+          "$ref": "#/$defs/RelpermData"
+        },
+        {
+          "$ref": "#/$defs/RFTData"
+        },
+        {
+          "$ref": "#/$defs/SeismicData"
+        },
+        {
+          "$ref": "#/$defs/SimulationTimeSeriesData"
+        },
+        {
+          "$ref": "#/$defs/SubcropData"
+        },
+        {
+          "$ref": "#/$defs/ThicknessData"
+        },
+        {
+          "$ref": "#/$defs/TimeData"
+        },
+        {
+          "$ref": "#/$defs/TimeSeriesData"
+        },
+        {
+          "$ref": "#/$defs/TransmissibilitiesData"
+        },
+        {
+          "$ref": "#/$defs/VelocityData"
+        },
+        {
+          "$ref": "#/$defs/VolumesData"
+        },
+        {
+          "$ref": "#/$defs/WellCompletionsData"
+        },
+        {
+          "$ref": "#/$defs/WellPicksData"
+        }
+      ],
+      "title": "AnyData"
+    },
+    "AnyStandardResult": {
+      "description": "The ``standard result`` field contains information about which standard result this\ndata object represents. Data that is tagged as such is a standard result from FMU\nthat conforms to a specified standard.\n\nThis class, ``AnyStandardResult``, acts as a container for different standard\nresults, with the exact standard result being identified by the\n``standard_result.name`` field.",
+      "discriminator": {
+        "propertyName": "name"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ErtParametersStandardResult"
+        },
+        {
+          "$ref": "#/$defs/FieldOutlineStandardResult"
+        },
+        {
+          "$ref": "#/$defs/InplaceVolumesStandardResult"
+        },
+        {
+          "$ref": "#/$defs/StructureDepthSurfaceStandardResult"
+        },
+        {
+          "$ref": "#/$defs/StructureDepthFaultSurfaceStandardResult"
+        },
+        {
+          "$ref": "#/$defs/StructureTimeSurfaceStandardResult"
+        },
+        {
+          "$ref": "#/$defs/StructureDepthIsochoreStandardResult"
+        },
+        {
+          "$ref": "#/$defs/StructureDepthFaultLinesStandardResult"
+        },
+        {
+          "$ref": "#/$defs/FluidContactSurfaceStandardResult"
+        },
+        {
+          "$ref": "#/$defs/FluidContactOutlineStandardResult"
+        }
+      ],
+      "title": "AnyStandardResult"
+    },
+    "Asset": {
+      "description": "The ``access.asset`` block contains information about the owner asset of\nthese data.",
+      "properties": {
+        "name": {
+          "examples": [
+            "Drogon"
+          ],
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Asset",
+      "type": "object"
+    },
+    "AxisOrientation": {
+      "description": "The axis orientation for a given data object.",
+      "enum": [
+        1,
+        -1
+      ],
+      "title": "AxisOrientation",
+      "type": "integer"
+    },
+    "BoundingBox2D": {
+      "description": "Contains the 2D coordinates within which a data object is contained.",
+      "properties": {
+        "xmax": {
+          "title": "Xmax",
+          "type": "number"
+        },
+        "xmin": {
+          "title": "Xmin",
+          "type": "number"
+        },
+        "ymax": {
+          "title": "Ymax",
+          "type": "number"
+        },
+        "ymin": {
+          "title": "Ymin",
+          "type": "number"
+        }
+      },
+      "required": [
+        "xmin",
+        "xmax",
+        "ymin",
+        "ymax"
+      ],
+      "title": "BoundingBox2D",
+      "type": "object"
+    },
+    "BoundingBox3D": {
+      "description": "Contains the 3D coordinates within which a data object is contained.",
+      "properties": {
+        "xmax": {
+          "title": "Xmax",
+          "type": "number"
+        },
+        "xmin": {
+          "title": "Xmin",
+          "type": "number"
+        },
+        "ymax": {
+          "title": "Ymax",
+          "type": "number"
+        },
+        "ymin": {
+          "title": "Ymin",
+          "type": "number"
+        },
+        "zmax": {
+          "title": "Zmax",
+          "type": "number"
+        },
+        "zmin": {
+          "title": "Zmin",
+          "type": "number"
+        }
+      },
+      "required": [
+        "xmin",
+        "xmax",
+        "ymin",
+        "ymax",
+        "zmin",
+        "zmax"
+      ],
+      "title": "BoundingBox3D",
+      "type": "object"
+    },
+    "CPGridPropertySpecification": {
+      "description": "Specifies relevant values describing a corner point grid property object.",
+      "properties": {
+        "codenames": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            {
+              "0": "shale",
+              "1": "sand"
+            }
+          ],
+          "title": "Codenames"
+        },
+        "ncol": {
+          "exclusiveMinimum": 0,
+          "title": "Ncol",
+          "type": "integer"
+        },
+        "nlay": {
+          "exclusiveMinimum": 0,
+          "title": "Nlay",
+          "type": "integer"
+        },
+        "nrow": {
+          "exclusiveMinimum": 0,
+          "title": "Nrow",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "nrow",
+        "ncol",
+        "nlay"
+      ],
+      "title": "CPGridPropertySpecification",
+      "type": "object"
+    },
+    "CPGridSpecification": {
+      "description": "Specifies relevant values describing a corner point grid object.",
+      "properties": {
+        "ncol": {
+          "exclusiveMinimum": 0,
+          "title": "Ncol",
+          "type": "integer"
+        },
+        "nlay": {
+          "exclusiveMinimum": 0,
+          "title": "Nlay",
+          "type": "integer"
+        },
+        "nrow": {
+          "exclusiveMinimum": 0,
+          "title": "Nrow",
+          "type": "integer"
+        },
+        "xscale": {
+          "title": "Xscale",
+          "type": "number"
+        },
+        "xshift": {
+          "title": "Xshift",
+          "type": "number"
+        },
+        "yscale": {
+          "title": "Yscale",
+          "type": "number"
+        },
+        "yshift": {
+          "title": "Yshift",
+          "type": "number"
+        },
+        "zonation": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ZoneDefinition"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Zonation"
+        },
+        "zscale": {
+          "title": "Zscale",
+          "type": "number"
+        },
+        "zshift": {
+          "title": "Zshift",
+          "type": "number"
+        }
+      },
+      "required": [
+        "nrow",
+        "ncol",
+        "nlay",
+        "xshift",
+        "yshift",
+        "zshift",
+        "xscale",
+        "yscale",
+        "zscale"
+      ],
+      "title": "CPGridSpecification",
+      "type": "object"
+    },
+    "Case": {
+      "description": "The ``fmu.case`` block contains information about the case from which this data\nobject was exported.\n\nA case represent a set of ensembles that belong together, either by being part of\nthe same run (i.e. history matching) or by being placed together by the user,\ncorresponding to /scratch/<asset>/<user>/<my case name>/.\n\n.. note:: If an FMU data object is exported outside the case context, this block\n   will not be present.",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "name": {
+          "examples": [
+            "MyCaseName"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/$defs/User"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "user",
+        "uuid"
+      ],
+      "title": "Case",
+      "type": "object"
+    },
+    "CaseMetadata": {
+      "description": "The FMU metadata model for an FMU case.\n\nA case represent a set of iterations that belong together, either by being part of\nthe same run (i.e. history matching) or by being placed together by the user,\ncorresponding to /scratch/<asset>/<user>/<my case name>/.",
+      "properties": {
+        "$schema": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "$Schema",
+          "type": "string"
+        },
+        "access": {
+          "$ref": "#/$defs/Access"
+        },
+        "class": {
+          "const": "case",
+          "title": "metadata_class",
+          "type": "string"
+        },
+        "fmu": {
+          "$ref": "#/$defs/FMUBase"
+        },
+        "masterdata": {
+          "$ref": "#/$defs/Masterdata"
+        },
+        "source": {
+          "default": "fmu",
+          "title": "Source",
+          "type": "string"
+        },
+        "tracklog": {
+          "$ref": "#/$defs/Tracklog"
+        },
+        "version": {
+          "default": "0.19.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "class",
+        "masterdata",
+        "tracklog",
+        "fmu",
+        "access"
+      ],
+      "title": "CaseMetadata",
+      "type": "object"
+    },
+    "Classification": {
+      "description": "The security classification for a given data object.",
+      "enum": [
+        "asset",
+        "internal",
+        "restricted"
+      ],
+      "title": "Classification",
+      "type": "string"
+    },
+    "Context": {
+      "description": "The ``fmu.context`` block contains the FMU context in which this data object\nwas produced.",
+      "properties": {
+        "stage": {
+          "$ref": "#/$defs/FMUContext"
+        }
+      },
+      "required": [
+        "stage"
+      ],
+      "title": "Context",
+      "type": "object"
+    },
+    "CoordinateSystem": {
+      "description": "The ``masterdata.smda.coordinate_system`` block contains the coordinate\nsystem known to SMDA.",
+      "properties": {
+        "identifier": {
+          "examples": [
+            "ST_WGS84_UTM37N_P32637"
+          ],
+          "title": "Identifier",
+          "type": "string"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identifier",
+        "uuid"
+      ],
+      "title": "CoordinateSystem",
+      "type": "object"
+    },
+    "CountryItem": {
+      "description": "A single country in the ``smda.masterdata.country`` list of countries\nknown to SMDA.",
+      "properties": {
+        "identifier": {
+          "examples": [
+            "Norway"
+          ],
+          "title": "Identifier",
+          "type": "string"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identifier",
+        "uuid"
+      ],
+      "title": "CountryItem",
+      "type": "object"
+    },
+    "CubeSpecification": {
+      "description": "Specifies relevant values describing a cube object, i.e. a seismic cube.",
+      "properties": {
+        "ncol": {
+          "exclusiveMinimum": 0,
+          "title": "Ncol",
+          "type": "integer"
+        },
+        "nlay": {
+          "exclusiveMinimum": 0,
+          "title": "Nlay",
+          "type": "integer"
+        },
+        "nrow": {
+          "exclusiveMinimum": 0,
+          "title": "Nrow",
+          "type": "integer"
+        },
+        "rotation": {
+          "title": "Rotation",
+          "type": "number"
+        },
+        "undef": {
+          "title": "Undef",
+          "type": "number"
+        },
+        "xinc": {
+          "exclusiveMinimum": 0,
+          "title": "Xinc",
+          "type": "number"
+        },
+        "xori": {
+          "title": "Xori",
+          "type": "number"
+        },
+        "yflip": {
+          "$ref": "#/$defs/AxisOrientation"
+        },
+        "yinc": {
+          "exclusiveMinimum": 0,
+          "title": "Yinc",
+          "type": "number"
+        },
+        "yori": {
+          "title": "Yori",
+          "type": "number"
+        },
+        "zflip": {
+          "$ref": "#/$defs/AxisOrientation"
+        },
+        "zinc": {
+          "exclusiveMinimum": 0,
+          "title": "Zinc",
+          "type": "number"
+        },
+        "zori": {
+          "title": "Zori",
+          "type": "number"
+        }
+      },
+      "required": [
+        "nrow",
+        "ncol",
+        "rotation",
+        "undef",
+        "xinc",
+        "yinc",
+        "xori",
+        "yflip",
+        "yori",
+        "nlay",
+        "zinc",
+        "zori",
+        "zflip"
+      ],
+      "title": "CubeSpecification",
+      "type": "object"
+    },
+    "DepthData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for depth type.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "depth",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "const": "depth",
+          "title": "Vertical Domain",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction",
+        "vertical_domain"
+      ],
+      "title": "DepthData",
+      "type": "object"
+    },
+    "DiscoveryItem": {
+      "description": "A single discovery in the ``masterdata.smda.discovery`` list of discoveries\nknown to SMDA.",
+      "properties": {
+        "short_identifier": {
+          "examples": [
+            "SomeDiscovery"
+          ],
+          "title": "Short Identifier",
+          "type": "string"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "short_identifier",
+        "uuid"
+      ],
+      "title": "DiscoveryItem",
+      "type": "object"
+    },
+    "Display": {
+      "description": "The ``display`` block contains information related to how this data object\nshould/could be displayed. As a general rule, the consumer of data is responsible\nfor figuring out how a specific data object shall be displayed. However, we use\nthis block to communicate preferences from the data producers perspective.\n\nWe also maintain this block due to legacy reasons. No data filtering logic should\nbe placed on the ``display`` block.",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        }
+      },
+      "title": "Display",
+      "type": "object"
+    },
+    "DomainReference": {
+      "enum": [
+        "msl",
+        "sb",
+        "rkb"
+      ],
+      "title": "DomainReference",
+      "type": "string"
+    },
+    "Ensemble": {
+      "description": "Ensemble information present as both ``fmu.ensemble`` and ``ert.ensemble``.\n\nAlthough ensemble information may be present in both blocks, within the same\nexperiment they are inconsistent.\n\n- In the FMU context, as ``fmu.ensemble``, this name is derived from the run path.\n  The ``name`` is derived from the run path, and the uuid is derived from the case\n  uuid and the ``name``.\n- In the Ert context, as ``ert.ensemble``, this name is derived from Ert UI\n  configuration and is consistent with what's inside of the Ert storage. The\n  ensemble uuid may differ within the same case if there are multiple reruns, as\n  each run of an experiment generates a new ensemble uuid in the storage.\n\nNote that this is true mostly for the ``ensemble`` context. It means that\n``fmu.ensemble`` != ``ert.ensemble``.",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "name": {
+          "examples": [
+            "iter-0",
+            "pred",
+            "default_0",
+            "ensemble"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "restart_from": {
+          "anyOf": [
+            {
+              "format": "uuid",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "title": "Restart From"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uuid"
+      ],
+      "title": "Ensemble",
+      "type": "object"
+    },
+    "EnsembleContext": {
+      "description": "The ``fmu.context`` block contains the FMU context in which this data object\nwas produced. Here ``stage`` is required to be ``ensemble``.",
+      "properties": {
+        "stage": {
+          "const": "ensemble",
+          "default": "ensemble",
+          "title": "Stage",
+          "type": "string"
+        }
+      },
+      "title": "EnsembleContext",
+      "type": "object"
+    },
+    "EnsembleMetadata": {
+      "description": "The FMU metadata model for an FMU ensemble.\n\nAn object representing a single Ensemble of a specific case.",
+      "properties": {
+        "$schema": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "$Schema",
+          "type": "string"
+        },
+        "access": {
+          "$ref": "#/$defs/Access"
+        },
+        "class": {
+          "const": "ensemble",
+          "title": "metadata_class",
+          "type": "string"
+        },
+        "fmu": {
+          "$ref": "#/$defs/FMUEnsemble"
+        },
+        "masterdata": {
+          "$ref": "#/$defs/Masterdata"
+        },
+        "source": {
+          "default": "fmu",
+          "title": "Source",
+          "type": "string"
+        },
+        "tracklog": {
+          "$ref": "#/$defs/Tracklog"
+        },
+        "version": {
+          "default": "0.19.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "class",
+        "masterdata",
+        "tracklog",
+        "fmu",
+        "access"
+      ],
+      "title": "EnsembleMetadata",
+      "type": "object"
+    },
+    "Entity": {
+      "description": "The ``fmu.entity`` block identifies data objects representing the same entity\nwithin a case, i.e. both realizations and aggregations of a particular entity\nwill share the same unique identifier.",
+      "properties": {
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uuid"
+      ],
+      "title": "Entity",
+      "type": "object"
+    },
+    "Ert": {
+      "description": "The ``fmu.ert`` block contains information about the current ert run.",
+      "properties": {
+        "ensemble": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ensemble"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "experiment": {
+          "$ref": "#/$defs/Experiment"
+        },
+        "simulation_mode": {
+          "$ref": "#/$defs/ErtSimulationMode"
+        }
+      },
+      "required": [
+        "experiment",
+        "simulation_mode"
+      ],
+      "title": "Ert",
+      "type": "object"
+    },
+    "ErtParametersStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represents.\n\nThis class contains metadata for the 'parameters' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/ert_parameters.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "parameters",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ErtParametersStandardResult",
+      "type": "object"
+    },
+    "ErtSimulationMode": {
+      "description": "The simulation mode ert was run in. These definitions come from\n`ert.mode_definitions`.",
+      "enum": [
+        "ensemble_experiment",
+        "ensemble_information_filter",
+        "ensemble_smoother",
+        "es_mda",
+        "evaluate_ensemble",
+        "manual_enif_update",
+        "manual_update",
+        "test_run",
+        "workflow"
+      ],
+      "title": "ErtSimulationMode",
+      "type": "string"
+    },
+    "Experiment": {
+      "description": "The ``fmu.ert.experiment`` block contains information about\nthe current ert experiment run.",
+      "properties": {
+        "id": {
+          "format": "uuid",
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "Experiment",
+      "type": "object"
+    },
+    "FMU": {
+      "dependencies": {
+        "aggregation": {
+          "not": {
+            "required": [
+              "realization"
+            ]
+          }
+        },
+        "realization": {
+          "not": {
+            "required": [
+              "aggregation"
+            ]
+          }
+        }
+      },
+      "description": "The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU\nresults data model can be applied to data from *other* sources - in which the\nfmu-specific stuff may not make sense or be applicable.",
+      "properties": {
+        "aggregation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Aggregation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "case": {
+          "$ref": "#/$defs/Case"
+        },
+        "context": {
+          "$ref": "#/$defs/Context"
+        },
+        "ensemble": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ensemble"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Entity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ert": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ert"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "iteration": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ensemble"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "model": {
+          "$ref": "#/$defs/Model"
+        },
+        "realization": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Realization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "workflow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Workflow"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "case",
+        "model",
+        "context"
+      ],
+      "title": "FMU",
+      "type": "object"
+    },
+    "FMUBase": {
+      "description": "The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU\nresults data model can be applied to data from *other* sources - in which the\nfmu-specific stuff may not make sense or be applicable.",
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/Case"
+        },
+        "model": {
+          "$ref": "#/$defs/Model"
+        }
+      },
+      "required": [
+        "case",
+        "model"
+      ],
+      "title": "FMUBase",
+      "type": "object"
+    },
+    "FMUContext": {
+      "description": "The context in which FMU was being run when data were generated.",
+      "enum": [
+        "case",
+        "iteration",
+        "ensemble",
+        "realization"
+      ],
+      "title": "FMUContext",
+      "type": "string"
+    },
+    "FMUEnsemble": {
+      "description": "The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU\nresults data model can be applied to data from *other* sources - in which the\nfmu-specific stuff may not make sense or be applicable.\nThis is a specialization of the FMU block for ``ensemble`` objects.",
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/Case"
+        },
+        "context": {
+          "$ref": "#/$defs/EnsembleContext"
+        },
+        "ensemble": {
+          "$ref": "#/$defs/Ensemble"
+        },
+        "model": {
+          "$ref": "#/$defs/Model"
+        }
+      },
+      "required": [
+        "case",
+        "model",
+        "context",
+        "ensemble"
+      ],
+      "title": "FMUEnsemble",
+      "type": "object"
+    },
+    "FMUIteration": {
+      "description": "Deprecated and replaced by :class:`FMUEnsemble`.",
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/Case"
+        },
+        "context": {
+          "$ref": "#/$defs/IterationContext"
+        },
+        "iteration": {
+          "$ref": "#/$defs/Ensemble"
+        },
+        "model": {
+          "$ref": "#/$defs/Model"
+        }
+      },
+      "required": [
+        "case",
+        "model",
+        "context",
+        "iteration"
+      ],
+      "title": "FMUIteration",
+      "type": "object"
+    },
+    "FMURealization": {
+      "description": "The ``fmu`` block contains all attributes specific to FMU. The idea is that the FMU\nresults data model can be applied to data from *other* sources - in which the\nfmu-specific stuff may not make sense or be applicable.\nThis is a specialization of the FMU block for ``realization`` objects.",
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/Case"
+        },
+        "context": {
+          "$ref": "#/$defs/RealizationContext"
+        },
+        "ensemble": {
+          "$ref": "#/$defs/Ensemble"
+        },
+        "iteration": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ensemble"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "model": {
+          "$ref": "#/$defs/Model"
+        },
+        "realization": {
+          "$ref": "#/$defs/Realization"
+        }
+      },
+      "required": [
+        "case",
+        "model",
+        "context",
+        "ensemble",
+        "realization"
+      ],
+      "title": "FMURealization",
+      "type": "object"
+    },
+    "FaciesThicknessData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for facies thickness.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "facies_thickness",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "FaciesThicknessData",
+      "type": "object"
+    },
+    "FaultLinesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for fault lines.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "fault_lines",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "FaultLinesData",
+      "type": "object"
+    },
+    "FaultPropertiesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for fault properties.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "fault_properties",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "FaultPropertiesData",
+      "type": "object"
+    },
+    "FaultRoomSurfaceSpecification": {
+      "description": "Specifies relevant values describing a Faultroom surface object.",
+      "properties": {
+        "faults": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Faults",
+          "type": "array"
+        },
+        "horizons": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Horizons",
+          "type": "array"
+        },
+        "juxtaposition_fw": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Juxtaposition Fw",
+          "type": "array"
+        },
+        "juxtaposition_hw": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Juxtaposition Hw",
+          "type": "array"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "properties": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Properties",
+          "type": "array"
+        }
+      },
+      "required": [
+        "horizons",
+        "faults",
+        "juxtaposition_hw",
+        "juxtaposition_fw",
+        "properties",
+        "name"
+      ],
+      "title": "FaultRoomSurfaceSpecification",
+      "type": "object"
+    },
+    "FaultSurfaceData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for faults represented as triangulated surfaces.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "fault_surface",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "FaultSurfaceData",
+      "type": "object"
+    },
+    "FieldItem": {
+      "description": "A single field in the ``masterdata.smda.field`` list of fields\nknown to SMDA.",
+      "properties": {
+        "identifier": {
+          "examples": [
+            "OseFax"
+          ],
+          "title": "Identifier",
+          "type": "string"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identifier",
+        "uuid"
+      ],
+      "title": "FieldItem",
+      "type": "object"
+    },
+    "FieldOutline": {
+      "description": "A block describing a field outline. Shall be present if ``data.content``\n== \"field_outline\"",
+      "properties": {
+        "contact": {
+          "title": "Contact",
+          "type": "string"
+        }
+      },
+      "required": [
+        "contact"
+      ],
+      "title": "FieldOutline",
+      "type": "object"
+    },
+    "FieldOutlineData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for field outlines.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "field_outline",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "field_outline": {
+          "$ref": "#/$defs/FieldOutline"
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction",
+        "field_outline"
+      ],
+      "title": "FieldOutlineData",
+      "type": "object"
+    },
+    "FieldOutlineStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'field_outline' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/field_outline.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "field_outline",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "FieldOutlineStandardResult",
+      "type": "object"
+    },
+    "FieldRegion": {
+      "description": "A block describing a field region. Shall be present if ``data.content``\n== \"field_region\"",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "FieldRegion",
+      "type": "object"
+    },
+    "FieldRegionData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for field regions.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "field_region",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "field_region": {
+          "$ref": "#/$defs/FieldRegion"
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction",
+        "field_region"
+      ],
+      "title": "FieldRegionData",
+      "type": "object"
+    },
+    "File": {
+      "description": "The ``file`` block contains references to this data object as a file on a disk.\nA filename in this context can be actual, or abstract. Particularly the\n``relative_path`` is, and will most likely remain, an important identifier for\nindividual file objects within an FMU case - irrespective of the existance of an\nactual file system. For this reason, the ``relative_path`` - as well as the\n``checksum_md5`` will be generated even if a file is not saved to disk. The\n``absolute_path`` will only be generated in the case of actually creating a file on\ndisk and is not required under this schema.",
+      "properties": {
+        "absolute_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "/abs/path/share/results/maps/volantis_gp_base--depth.gri"
+          ],
+          "title": "Absolute Path"
+        },
+        "checksum_md5": {
+          "examples": [
+            "fa4d055b113ae5282796e328cde0ffa4"
+          ],
+          "pattern": "^([a-f\\d]{32}|[A-F\\d]{32})$",
+          "title": "Checksum Md5",
+          "type": "string"
+        },
+        "relative_path": {
+          "examples": [
+            "realization-0/iter-0/share/results/maps/volantis_gp_base--depth.gri"
+          ],
+          "title": "Relative Path",
+          "type": "string"
+        },
+        "runpath_relative_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "share/results/maps/volantis_gp_base--depth.gri"
+          ],
+          "title": "Runpath Relative Path"
+        },
+        "size_bytes": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Size Bytes"
+        }
+      },
+      "required": [
+        "relative_path",
+        "checksum_md5"
+      ],
+      "title": "File",
+      "type": "object"
+    },
+    "FileFormat": {
+      "description": "The format of a given data object.",
+      "enum": [
+        "parquet",
+        "json",
+        "csv",
+        "csv|xtgeo",
+        "irap_ascii",
+        "irap_binary",
+        "roff",
+        "segy",
+        "openvds",
+        "tsurf"
+      ],
+      "title": "FileFormat",
+      "type": "string"
+    },
+    "FileSchema": {
+      "description": "The schema identifying the format of a standard result.",
+      "properties": {
+        "url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version",
+        "url"
+      ],
+      "title": "FileSchema",
+      "type": "object"
+    },
+    "FluidContact": {
+      "description": "A block describing a fluid contact. Shall be present if ``data.content``\n== ``fluid_contact``.",
+      "properties": {
+        "contact": {
+          "$ref": "#/$defs/FluidContactType",
+          "examples": [
+            "owc",
+            "fwl"
+          ]
+        },
+        "truncated": {
+          "default": false,
+          "title": "Truncated",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "contact"
+      ],
+      "title": "FluidContact",
+      "type": "object"
+    },
+    "FluidContactData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for fluid contacts.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "fluid_contact",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "fluid_contact": {
+          "$ref": "#/$defs/FluidContact"
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction",
+        "fluid_contact"
+      ],
+      "title": "FluidContactData",
+      "type": "object"
+    },
+    "FluidContactOutlineStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'fluid_contact_outline' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/fluid_contact_outline.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "fluid_contact_outline",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "FluidContactOutlineStandardResult",
+      "type": "object"
+    },
+    "FluidContactSurfaceStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'fluid_contact_surface' standard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "fluid_contact_surface",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "FluidContactSurfaceStandardResult",
+      "type": "object"
+    },
+    "FluidContactType": {
+      "description": "The type of fluid contact.",
+      "enum": [
+        "fgl",
+        "fwl",
+        "goc",
+        "gwc",
+        "owc"
+      ],
+      "title": "FluidContactType",
+      "type": "string"
+    },
+    "Geometry": {
+      "description": "The geometry of the object, i.e. the grid that an object representing a grid\nproperty is derivative of.",
+      "properties": {
+        "name": {
+          "examples": [
+            "MyGrid"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "relative_path": {
+          "examples": [
+            "some/relative/path/mygrid.roff"
+          ],
+          "title": "Relative Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "relative_path"
+      ],
+      "title": "Geometry",
+      "type": "object"
+    },
+    "GridModel": {
+      "description": "A block containing information pertaining to grid model content.\nSee :class:`GridModel`.\n\n.. warning:: This has currently no function and is likely to be deprecated.",
+      "properties": {
+        "name": {
+          "examples": [
+            "MyGrid"
+          ],
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "GridModel",
+      "type": "object"
+    },
+    "InplaceVolumesStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represents.\n\nThis class contains metadata for the 'inplace_volumes' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/inplace_volumes.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "inplace_volumes",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "InplaceVolumesStandardResult",
+      "type": "object"
+    },
+    "IterationContext": {
+      "description": "The ``fmu.context`` block contains the FMU context in which this data object\nwas produced. Here ``stage`` is required to be ``iteration``.",
+      "properties": {
+        "stage": {
+          "const": "iteration",
+          "default": "iteration",
+          "title": "Stage",
+          "type": "string"
+        }
+      },
+      "title": "IterationContext",
+      "type": "object"
+    },
+    "IterationMetadata": {
+      "description": "Deprecated and replaced by :class:`EnsembleMetadata`.",
+      "properties": {
+        "$schema": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "$Schema",
+          "type": "string"
+        },
+        "access": {
+          "$ref": "#/$defs/Access"
+        },
+        "class": {
+          "const": "iteration",
+          "title": "metadata_class",
+          "type": "string"
+        },
+        "fmu": {
+          "$ref": "#/$defs/FMUIteration"
+        },
+        "masterdata": {
+          "$ref": "#/$defs/Masterdata"
+        },
+        "source": {
+          "default": "fmu",
+          "title": "Source",
+          "type": "string"
+        },
+        "tracklog": {
+          "$ref": "#/$defs/Tracklog"
+        },
+        "version": {
+          "default": "0.19.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "class",
+        "masterdata",
+        "tracklog",
+        "fmu",
+        "access"
+      ],
+      "title": "IterationMetadata",
+      "type": "object"
+    },
+    "KPProductData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for KP products.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "khproduct",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "KPProductData",
+      "type": "object"
+    },
+    "Layer": {
+      "description": "Used to represent a layer, i.e. top or bottom, of a given stratigraphic\ninterval.",
+      "properties": {
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "stratigraphic": {
+          "default": false,
+          "title": "Stratigraphic",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Layer",
+      "type": "object"
+    },
+    "Layout": {
+      "description": "The layout of a given data object.",
+      "enum": [
+        "regular",
+        "unset",
+        "cornerpoint",
+        "table",
+        "dictionary",
+        "triangulated"
+      ],
+      "title": "Layout",
+      "type": "string"
+    },
+    "LiftCurvesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for lift curves.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "lift_curves",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "LiftCurvesData",
+      "type": "object"
+    },
+    "Masterdata": {
+      "description": "The ``masterdata`` block contains information related to masterdata.\nCurrently, SMDA holds the masterdata.",
+      "properties": {
+        "smda": {
+          "$ref": "#/$defs/Smda"
+        }
+      },
+      "required": [
+        "smda"
+      ],
+      "title": "Masterdata",
+      "type": "object"
+    },
+    "Model": {
+      "description": "The ``fmu.model`` block contains information about the model used.\n\n.. note::\n   Synonyms for \"model\" in this context are \"template\", \"setup\", etc. The term\n   \"model\" is ultra-generic but was chosen before e.g. \"template\" as the latter\n   deviates from daily communications and is, if possible, even more generic\n   than \"model\".",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "name": {
+          "examples": [
+            "Drogon"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "revision": {
+          "examples": [
+            "21.0.0.dev"
+          ],
+          "title": "Revision",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "revision"
+      ],
+      "title": "Model",
+      "type": "object"
+    },
+    "NamedAreaData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for named areas.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "named_area",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "NamedAreaData",
+      "type": "object"
+    },
+    "ObjectMetadata": {
+      "description": "The FMU metadata model for a given data object.",
+      "properties": {
+        "$schema": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "$Schema",
+          "type": "string"
+        },
+        "access": {
+          "$ref": "#/$defs/SsdlAccess"
+        },
+        "class": {
+          "enum": [
+            "surface",
+            "table",
+            "cpgrid",
+            "cpgrid_property",
+            "polygons",
+            "cube",
+            "well",
+            "points",
+            "dictionary"
+          ],
+          "title": "metadata_class",
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/AnyData"
+        },
+        "display": {
+          "$ref": "#/$defs/Display"
+        },
+        "file": {
+          "$ref": "#/$defs/File"
+        },
+        "fmu": {
+          "$ref": "#/$defs/FMU"
+        },
+        "masterdata": {
+          "$ref": "#/$defs/Masterdata"
+        },
+        "source": {
+          "default": "fmu",
+          "title": "Source",
+          "type": "string"
+        },
+        "tracklog": {
+          "$ref": "#/$defs/Tracklog"
+        },
+        "version": {
+          "default": "0.19.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "class",
+        "masterdata",
+        "tracklog",
+        "fmu",
+        "access",
+        "data",
+        "file",
+        "display"
+      ],
+      "title": "ObjectMetadata",
+      "type": "object"
+    },
+    "OperatingSystem": {
+      "description": "The ``operating_system`` block contains information about the OS on which the\nensemble was run.",
+      "properties": {
+        "hostname": {
+          "examples": [
+            "st-123.equinor.com"
+          ],
+          "title": "Hostname",
+          "type": "string"
+        },
+        "operating_system": {
+          "examples": [
+            "Darwin-18.7.0-x86_64-i386-64bit"
+          ],
+          "title": "Operating System",
+          "type": "string"
+        },
+        "release": {
+          "examples": [
+            "18.7.0"
+          ],
+          "title": "Release",
+          "type": "string"
+        },
+        "system": {
+          "examples": [
+            "GNU/Linux"
+          ],
+          "title": "System",
+          "type": "string"
+        },
+        "version": {
+          "examples": [
+            "#1 SMP Tue Aug 27 21:37:59 PDT 2019"
+          ],
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "hostname",
+        "operating_system",
+        "release",
+        "system",
+        "version"
+      ],
+      "title": "OperatingSystem",
+      "type": "object"
+    },
+    "PVTData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for pvt data.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "pvt",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "PVTData",
+      "type": "object"
+    },
+    "ParametersData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for parameters.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "parameters",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "ParametersData",
+      "type": "object"
+    },
+    "PinchoutData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for pinchouts.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "pinchout",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "PinchoutData",
+      "type": "object"
+    },
+    "PointSpecification": {
+      "description": "Specifies relevant values describing an xyz points object.",
+      "properties": {
+        "attributes": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attributes"
+        },
+        "columns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Columns"
+        },
+        "num_columns": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            1,
+            9999
+          ],
+          "title": "Num Columns"
+        },
+        "num_rows": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            1,
+            9999
+          ],
+          "title": "Num Rows"
+        },
+        "size": {
+          "examples": [
+            1,
+            9999
+          ],
+          "minimum": 0,
+          "title": "Size",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "title": "PointSpecification",
+      "type": "object"
+    },
+    "PolygonsSpecification": {
+      "description": "Specifies relevant values describing a polygon object.",
+      "properties": {
+        "columns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Columns"
+        },
+        "npolys": {
+          "minimum": 0,
+          "title": "Npolys",
+          "type": "integer"
+        },
+        "num_columns": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            1,
+            9999
+          ],
+          "title": "Num Columns"
+        },
+        "num_rows": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            1,
+            9999
+          ],
+          "title": "Num Rows"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            1,
+            9999
+          ],
+          "title": "Size"
+        }
+      },
+      "required": [
+        "npolys"
+      ],
+      "title": "PolygonsSpecification",
+      "type": "object"
+    },
+    "ProductionNetworkData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for production network data.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "production_network",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "ProductionNetworkData",
+      "type": "object"
+    },
+    "Property": {
+      "description": "A block describing property data. Shall be present if ``data.content`\n== ``property``.",
+      "properties": {
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "porosity"
+          ],
+          "title": "Attribute"
+        },
+        "is_discrete": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Is Discrete"
+        }
+      },
+      "title": "Property",
+      "type": "object"
+    },
+    "PropertyData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for property data.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "property",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "property": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Property"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "PropertyData",
+      "type": "object"
+    },
+    "RFTData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for rft data.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "rft",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "RFTData",
+      "type": "object"
+    },
+    "Realization": {
+      "description": "The ``fmu.realization`` block contains information about the realization this\ndata object belongs to.",
+      "properties": {
+        "id": {
+          "minimum": 0,
+          "title": "Id",
+          "type": "integer"
+        },
+        "is_reference": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Is Reference"
+        },
+        "name": {
+          "examples": [
+            "realization-0"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "uuid"
+      ],
+      "title": "Realization",
+      "type": "object"
+    },
+    "RealizationContext": {
+      "description": "The ``fmu.context`` block contains the FMU context in which this data object\nwas produced. Here ``stage`` is required to be ``realization``.",
+      "properties": {
+        "stage": {
+          "const": "realization",
+          "default": "realization",
+          "title": "Stage",
+          "type": "string"
+        }
+      },
+      "title": "RealizationContext",
+      "type": "object"
+    },
+    "RealizationMetadata": {
+      "description": "The FMU metadata model for an FMU Realization.\n\nAn object representing a single Realization of a specific Ensemble.",
+      "properties": {
+        "$schema": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "$Schema",
+          "type": "string"
+        },
+        "access": {
+          "$ref": "#/$defs/Access"
+        },
+        "class": {
+          "const": "realization",
+          "title": "metadata_class",
+          "type": "string"
+        },
+        "fmu": {
+          "$ref": "#/$defs/FMURealization"
+        },
+        "masterdata": {
+          "$ref": "#/$defs/Masterdata"
+        },
+        "source": {
+          "default": "fmu",
+          "title": "Source",
+          "type": "string"
+        },
+        "tracklog": {
+          "$ref": "#/$defs/Tracklog"
+        },
+        "version": {
+          "default": "0.19.0",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "class",
+        "masterdata",
+        "tracklog",
+        "fmu",
+        "access"
+      ],
+      "title": "RealizationMetadata",
+      "type": "object"
+    },
+    "RegionsData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for regions.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "regions",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "RegionsData",
+      "type": "object"
+    },
+    "RelpermData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for relperm.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "relperm",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "RelpermData",
+      "type": "object"
+    },
+    "Seismic": {
+      "description": "A block describing seismic data. Shall be present if ``data.content``\n== ``seismic``.",
+      "properties": {
+        "attribute": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "amplitude_timeshifted"
+          ],
+          "title": "Attribute"
+        },
+        "calculation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "mean"
+          ],
+          "title": "Calculation"
+        },
+        "filter_size": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Filter Size"
+        },
+        "scaling_factor": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Scaling Factor"
+        },
+        "stacking_offset": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "0-15"
+          ],
+          "title": "Stacking Offset"
+        },
+        "zrange": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Zrange"
+        }
+      },
+      "title": "Seismic",
+      "type": "object"
+    },
+    "SeismicData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for seismics.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "seismic",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "seismic": {
+          "$ref": "#/$defs/Seismic"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction",
+        "seismic"
+      ],
+      "title": "SeismicData",
+      "type": "object"
+    },
+    "SimulationTimeSeriesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for simulation time series. This is a time series\nresult derived from some simulator like OPM Flow.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "simulationtimeseries",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "SimulationTimeSeriesData",
+      "type": "object"
+    },
+    "Smda": {
+      "description": "The ``masterdata.smda`` block contains SMDA-related attributes.",
+      "properties": {
+        "coordinate_system": {
+          "$ref": "#/$defs/CoordinateSystem"
+        },
+        "country": {
+          "items": {
+            "$ref": "#/$defs/CountryItem"
+          },
+          "title": "Country",
+          "type": "array"
+        },
+        "discovery": {
+          "items": {
+            "$ref": "#/$defs/DiscoveryItem"
+          },
+          "title": "Discovery",
+          "type": "array"
+        },
+        "field": {
+          "items": {
+            "$ref": "#/$defs/FieldItem"
+          },
+          "title": "Field",
+          "type": "array"
+        },
+        "stratigraphic_column": {
+          "$ref": "#/$defs/StratigraphicColumn"
+        }
+      },
+      "required": [
+        "coordinate_system",
+        "country",
+        "discovery",
+        "field",
+        "stratigraphic_column"
+      ],
+      "title": "Smda",
+      "type": "object"
+    },
+    "SmdaEntity": {
+      "description": "The stratigraphic entity (horizon name, zone name etc) known to SMDA.",
+      "properties": {
+        "identifier": {
+          "examples": [
+            "Viking Gp. Top"
+          ],
+          "title": "Identifier",
+          "type": "string"
+        },
+        "uuid": {
+          "anyOf": [
+            {
+              "format": "uuid",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "title": "Uuid"
+        }
+      },
+      "required": [
+        "identifier"
+      ],
+      "title": "SmdaEntity",
+      "type": "object"
+    },
+    "Ssdl": {
+      "description": "The ``access.ssdl`` block contains information related to SSDL.\nNote that this is kept due to legacy.",
+      "properties": {
+        "access_level": {
+          "$ref": "#/$defs/Classification"
+        },
+        "rep_include": {
+          "title": "Rep Include",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "access_level",
+        "rep_include"
+      ],
+      "title": "Ssdl",
+      "type": "object"
+    },
+    "SsdlAccess": {
+      "description": "The ``access`` block contains information related to access control for\nthis data object, with legacy SSDL settings.",
+      "properties": {
+        "asset": {
+          "$ref": "#/$defs/Asset"
+        },
+        "classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Classification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ssdl": {
+          "$ref": "#/$defs/Ssdl"
+        }
+      },
+      "required": [
+        "asset",
+        "ssdl"
+      ],
+      "title": "SsdlAccess",
+      "type": "object"
+    },
+    "StratigraphicColumn": {
+      "description": "The ``masterdata.smda.stratigraphic_column`` block contains the\nstratigraphic column known to SMDA.",
+      "properties": {
+        "identifier": {
+          "examples": [
+            "DROGON_2020"
+          ],
+          "title": "Identifier",
+          "type": "string"
+        },
+        "uuid": {
+          "examples": [
+            "15ce3b84-766f-4c93-9050-b154861f9100"
+          ],
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identifier",
+        "uuid"
+      ],
+      "title": "StratigraphicColumn",
+      "type": "object"
+    },
+    "StructureDepthFaultLinesStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_depth_fault_lines' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/structure_depth_fault_lines.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "structure_depth_fault_lines",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureDepthFaultLinesStandardResult",
+      "type": "object"
+    },
+    "StructureDepthFaultSurfaceStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_depth_fault_surface'\nstandard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "structure_depth_fault_surface",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureDepthFaultSurfaceStandardResult",
+      "type": "object"
+    },
+    "StructureDepthIsochoreStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_depth_isochore' standard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "structure_depth_isochore",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureDepthIsochoreStandardResult",
+      "type": "object"
+    },
+    "StructureDepthSurfaceStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_depth_surface' standard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "structure_depth_surface",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureDepthSurfaceStandardResult",
+      "type": "object"
+    },
+    "StructureTimeSurfaceStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represent.\nThis class contains metadata for the 'structure_time_surface' standard result.",
+      "properties": {
+        "file_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileSchema"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "const": "structure_time_surface",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "StructureTimeSurfaceStandardResult",
+      "type": "object"
+    },
+    "SubcropData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for subcrops.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "subcrop",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "SubcropData",
+      "type": "object"
+    },
+    "SurfaceSpecification": {
+      "description": "Specifies relevant values describing a regular surface object.",
+      "properties": {
+        "ncol": {
+          "exclusiveMinimum": 0,
+          "title": "Ncol",
+          "type": "integer"
+        },
+        "nrow": {
+          "exclusiveMinimum": 0,
+          "title": "Nrow",
+          "type": "integer"
+        },
+        "rotation": {
+          "title": "Rotation",
+          "type": "number"
+        },
+        "undef": {
+          "title": "Undef",
+          "type": "number"
+        },
+        "xinc": {
+          "exclusiveMinimum": 0,
+          "title": "Xinc",
+          "type": "number"
+        },
+        "xori": {
+          "title": "Xori",
+          "type": "number"
+        },
+        "yflip": {
+          "$ref": "#/$defs/AxisOrientation"
+        },
+        "yinc": {
+          "exclusiveMinimum": 0,
+          "title": "Yinc",
+          "type": "number"
+        },
+        "yori": {
+          "title": "Yori",
+          "type": "number"
+        }
+      },
+      "required": [
+        "nrow",
+        "ncol",
+        "rotation",
+        "undef",
+        "xinc",
+        "yinc",
+        "xori",
+        "yflip",
+        "yori"
+      ],
+      "title": "SurfaceSpecification",
+      "type": "object"
+    },
+    "SystemInformation": {
+      "description": "The ``tracklog.sysinfo`` block contains information about the system upon which\nthese data were exported from.",
+      "properties": {
+        "fmu-dataio": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Version"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "1.2.3"
+          ]
+        },
+        "komodo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Version"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "2023.12.05-py38"
+          ]
+        },
+        "operating_system": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperatingSystem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "SystemInformation",
+      "type": "object"
+    },
+    "TableSpecification": {
+      "description": "Specifies relevant values describing a generic tabular data object.",
+      "properties": {
+        "columns": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Columns",
+          "type": "array"
+        },
+        "num_columns": {
+          "examples": [
+            1,
+            9999
+          ],
+          "minimum": 0,
+          "title": "Num Columns",
+          "type": "integer"
+        },
+        "num_rows": {
+          "examples": [
+            1,
+            9999
+          ],
+          "minimum": 0,
+          "title": "Num Rows",
+          "type": "integer"
+        },
+        "size": {
+          "examples": [
+            1,
+            9999
+          ],
+          "minimum": 0,
+          "title": "Size",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "columns",
+        "num_columns",
+        "num_rows",
+        "size"
+      ],
+      "title": "TableSpecification",
+      "type": "object"
+    },
+    "ThicknessData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for thickness.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "thickness",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "ThicknessData",
+      "type": "object"
+    },
+    "Time": {
+      "description": "A block containing lists of objects describing timestamp information for this\ndata object, if applicable, like Flow simulator restart dates, or dates for seismic\n4D surveys.  See :class:`Time`.\n\n.. note:: ``data.time`` items can currently hold a maximum of two values.",
+      "properties": {
+        "t0": {
+          "$ref": "#/$defs/Timestamp"
+        },
+        "t1": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "t0"
+      ],
+      "title": "Time",
+      "type": "object"
+    },
+    "TimeData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for time.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "time",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "const": "time",
+          "title": "Vertical Domain",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction",
+        "vertical_domain"
+      ],
+      "title": "TimeData",
+      "type": "object"
+    },
+    "TimeSeriesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for time series.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "timeseries",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "TimeSeriesData",
+      "type": "object"
+    },
+    "Timestamp": {
+      "description": "A timestamp object contains a datetime representation of the time\nbeing marked and a string label for this timestamp.",
+      "properties": {
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "base",
+            "monitor",
+            "mylabel"
+          ],
+          "title": "Label"
+        },
+        "value": {
+          "examples": [
+            "2020-10-28T14:28:02"
+          ],
+          "format": "iso-date-time",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "title": "Timestamp",
+      "type": "object"
+    },
+    "TrackLogEventType": {
+      "description": "The type of event being logged",
+      "enum": [
+        "created",
+        "updated",
+        "merged"
+      ],
+      "title": "TrackLogEventType",
+      "type": "string"
+    },
+    "Tracklog": {
+      "description": "The ``tracklog`` block contains a record of events recorded on these data.\nThis data object describes the list of tracklog events, in addition to functionality\nfor constructing a tracklog and adding new records to it.",
+      "items": {
+        "$ref": "#/$defs/TracklogEvent"
+      },
+      "title": "Tracklog",
+      "type": "array"
+    },
+    "TracklogEvent": {
+      "description": "The ``tracklog`` block contains a record of events recorded on these data.\nThis data object describes a tracklog event.",
+      "properties": {
+        "datetime": {
+          "examples": [
+            "2020-10-28T14:28:024286Z"
+          ],
+          "format": "date-time",
+          "title": "Datetime",
+          "type": "string"
+        },
+        "event": {
+          "$ref": "#/$defs/TrackLogEventType"
+        },
+        "sysinfo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SystemInformation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "user": {
+          "$ref": "#/$defs/User"
+        }
+      },
+      "required": [
+        "datetime",
+        "event",
+        "user"
+      ],
+      "title": "TracklogEvent",
+      "type": "object"
+    },
+    "TransmissibilitiesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for transmissibilities.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "transmissibilities",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "TransmissibilitiesData",
+      "type": "object"
+    },
+    "TriangulatedSurfaceSpecification": {
+      "description": "Specifies relevant values describing a triangulated surface.",
+      "properties": {
+        "num_triangles": {
+          "minimum": 0,
+          "title": "Num Triangles",
+          "type": "integer"
+        },
+        "num_vertices": {
+          "minimum": 0,
+          "title": "Num Vertices",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "num_vertices",
+        "num_triangles"
+      ],
+      "title": "TriangulatedSurfaceSpecification",
+      "type": "object"
+    },
+    "User": {
+      "description": "The ``user`` block holds information about the user.",
+      "properties": {
+        "id": {
+          "examples": [
+            "peesv",
+            "jriv"
+          ],
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "User",
+      "type": "object"
+    },
+    "VelocityData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for velocities.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "velocity",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "VelocityData",
+      "type": "object"
+    },
+    "Version": {
+      "description": "A generic block that contains a string representing the version of\nsomething.",
+      "properties": {
+        "version": {
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "title": "Version",
+      "type": "object"
+    },
+    "VerticalDomain": {
+      "enum": [
+        "depth",
+        "time"
+      ],
+      "title": "VerticalDomain",
+      "type": "string"
+    },
+    "VolumesData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for volumes.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "volumes",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "VolumesData",
+      "type": "object"
+    },
+    "WellCompletionsData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for well completions.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "well_completions",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "WellCompletionsData",
+      "type": "object"
+    },
+    "WellPicksData": {
+      "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for well picks.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox3D"
+            },
+            {
+              "$ref": "#/$defs/BoundingBox2D"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Bbox"
+        },
+        "content": {
+          "const": "wellpicks",
+          "title": "Content",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "domain_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DomainReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "msl",
+            "sb",
+            "rkb"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/FileFormat",
+          "examples": [
+            "irap_binary"
+          ]
+        },
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Geometry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "grid_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_observation": {
+          "title": "Is Observation",
+          "type": "boolean"
+        },
+        "is_prediction": {
+          "title": "Is Prediction",
+          "type": "boolean"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "regular",
+            "cornerpoint"
+          ]
+        },
+        "name": {
+          "examples": [
+            "VIKING GP. Top"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "offset": {
+          "default": 0.0,
+          "title": "Offset",
+          "type": "number"
+        },
+        "smda_entity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SmdaEntity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CPGridPropertySpecification"
+            },
+            {
+              "$ref": "#/$defs/CPGridSpecification"
+            },
+            {
+              "$ref": "#/$defs/FaultRoomSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/PointSpecification"
+            },
+            {
+              "$ref": "#/$defs/CubeSpecification"
+            },
+            {
+              "$ref": "#/$defs/PolygonsSpecification"
+            },
+            {
+              "$ref": "#/$defs/SurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TriangulatedSurfaceSpecification"
+            },
+            {
+              "$ref": "#/$defs/TableSpecification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Spec"
+        },
+        "standard_result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyStandardResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stratigraphic": {
+          "title": "Stratigraphic",
+          "type": "boolean"
+        },
+        "table_index": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            [
+              "ZONE",
+              "REGION"
+            ]
+          ],
+          "title": "Table Index"
+        },
+        "tagname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "ds_extract_geogrid",
+            "ds_post_strucmod"
+          ],
+          "title": "Tagname"
+        },
+        "time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "top": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Layer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "undef_is_zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Undef Is Zero"
+        },
+        "unit": {
+          "default": "",
+          "examples": [
+            "m"
+          ],
+          "title": "Unit",
+          "type": "string"
+        },
+        "vertical_domain": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalDomain"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "examples": [
+            "depth",
+            "time"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "name",
+        "stratigraphic",
+        "format",
+        "is_observation",
+        "is_prediction"
+      ],
+      "title": "WellPicksData",
+      "type": "object"
+    },
+    "Workflow": {
+      "description": "The ``fmu.workflow`` block refers to specific subworkflows within the large\nFMU workflow being ran. This has not been standardized, mainly due to the lack of\nprogrammatic access to the workflows being run in important software within FMU.\n\n.. note:: A key usage of ``fmu.workflow.reference`` is related to ensuring\n   uniqueness of data objects.",
+      "properties": {
+        "reference": {
+          "title": "Reference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reference"
+      ],
+      "title": "Workflow",
+      "type": "object"
+    },
+    "ZoneDefinition": {
+      "description": "Zone name and corresponding layer index min/max",
+      "properties": {
+        "max_layer_idx": {
+          "minimum": 0,
+          "title": "Max Layer Idx",
+          "type": "integer"
+        },
+        "min_layer_idx": {
+          "minimum": 0,
+          "title": "Min Layer Idx",
+          "type": "integer"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "min_layer_idx",
+        "max_layer_idx"
+      ],
+      "title": "ZoneDefinition",
+      "type": "object"
+    }
+  },
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.19.0/fmu_results.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "discriminator": {
+    "propertyName": "class"
+  },
+  "if": {
+    "properties": {
+      "class": {
+        "enum": [
+          "table",
+          "surface"
+        ]
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/CaseMetadata"
+    },
+    {
+      "$ref": "#/$defs/ObjectMetadata"
+    },
+    {
+      "$ref": "#/$defs/RealizationMetadata"
+    },
+    {
+      "$ref": "#/$defs/IterationMetadata"
+    },
+    {
+      "$ref": "#/$defs/EnsembleMetadata"
+    }
+  ],
+  "then": {
+    "properties": {
+      "data": {
+        "required": [
+          "spec"
+        ]
+      }
+    }
+  },
+  "title": "FmuResults"
+}

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -44,9 +44,13 @@ if TYPE_CHECKING:
 class FmuResultsSchema(SchemaBase):
     """The main metadata export describing the results."""
 
-    VERSION: VersionStr = "0.18.0"
+    VERSION: VersionStr = "0.19.0"
 
     VERSION_CHANGELOG: str = """
+    #### 0.19.0
+
+    - Added 'codenames' to 'data.spec' for discrete grid properties.
+
     #### 0.18.0
 
     - Added dedicated link to SMDA stratigraphic column

--- a/src/fmu/datamodels/fmu_results/specification.py
+++ b/src/fmu/datamodels/fmu_results/specification.py
@@ -128,6 +128,11 @@ class ZoneDefinition(BaseModel):
 class CPGridPropertySpecification(RowColumnLayer):
     """Specifies relevant values describing a corner point grid property object."""
 
+    codenames: dict[int, str] | None = Field(
+        default=None, examples=[{0: "shale", 1: "sand"}]
+    )
+    """Mapping from discrete property values to corresponding names."""
+
 
 # TODO: Base on TableSpecification when we only support table export format for polygons
 class PolygonsSpecification(BaseModel):


### PR DESCRIPTION
Adresses https://github.com/equinor/fmu-dataio/issues/998

PR to add an optional codenames field to a grid property specification. 
Optional since it will not be relevant for continuous properties.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅