### PR TITLE
ENH: Add 'simulator_fipregions_mapping' standard result

### DIFF
--- a/schemas/0.19.0/fmu_results.json
+++ b/schemas/0.19.0/fmu_results.json
@@ -232,6 +232,9 @@
           "$ref": "#/$defs/InplaceVolumesStandardResult"
         },
         {
+          "$ref": "#/$defs/SimulatorFipregionsMappingStandardResult"
+        },
+        {
           "$ref": "#/$defs/StructureDepthSurfaceStandardResult"
         },
         {
@@ -5203,6 +5206,28 @@
         "is_prediction"
       ],
       "title": "MappingData",
+      "type": "object"
+    },
+    "SimulatorFipregionsMappingStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represents.\n\nThis class contains metadata for the 'simulator_fipregions_mapping'\nstandard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/simulator_fipregions_mapping.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "simulator_fipregions_mapping",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "SimulatorFipregionsMappingStandardResult",
       "type": "object"
     },
     "Masterdata": {

--- a/schemas/file_formats/0.1.0/simulator_fipregions_mapping.json
+++ b/schemas/file_formats/0.1.0/simulator_fipregions_mapping.json
@@ -1,0 +1,38 @@
+{
+  "$defs": {
+    "SimulatorFipregionsMappingResultRow": {
+      "description": "Represents the columns of a row in a simulator fipregions mapping export.\n\nThese fields are the current agreed upon standard result. Changes to the fields or\ntheir validation should cause the version defined in the standard result schema to\nincrease the version number in a way that corresponds to the schema versioning\nspecification (i.e. they are a patch, minor, or major change).",
+      "properties": {
+        "FIPNUM": {
+          "minimum": 0,
+          "title": "Fipnum",
+          "type": "integer"
+        },
+        "REGION": {
+          "title": "Region",
+          "type": "string"
+        },
+        "ZONE": {
+          "title": "Zone",
+          "type": "string"
+        }
+      },
+      "required": [
+        "FIPNUM",
+        "ZONE",
+        "REGION"
+      ],
+      "title": "SimulatorFipregionsMappingResultRow",
+      "type": "object"
+    }
+  },
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/simulator_fipregions_mapping.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Represents the resultant simulator fipregions mapping parquet file, which is\nnaturally a list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
+  "items": {
+    "$ref": "#/$defs/SimulatorFipregionsMappingResultRow"
+  },
+  "title": "SimulatorFipregionsMappingResult",
+  "type": "array",
+  "version": "0.1.0"
+}

--- a/src/fmu/datamodels/__init__.py
+++ b/src/fmu/datamodels/__init__.py
@@ -14,6 +14,8 @@ from .standard_results import (
     FluidContactOutlineSchema,
     InplaceVolumesResult,
     InplaceVolumesSchema,
+    SimulatorFipregionsMappingResult,
+    SimulatorFipregionsMappingSchema,
     StructureDepthFaultLinesResult,
     StructureDepthFaultLinesSchema,
 )
@@ -38,6 +40,8 @@ __all__ = [
     "FluidContactOutlineSchema",
     "InplaceVolumesResult",
     "InplaceVolumesSchema",
+    "SimulatorFipregionsMappingResult",
+    "SimulatorFipregionsMappingSchema",
     "StructureDepthFaultLinesResult",
     "StructureDepthFaultLinesSchema",
 ]
@@ -48,5 +52,6 @@ schemas: list[type[SchemaBase]] = [
     FieldOutlineSchema,
     FluidContactOutlineSchema,
     InplaceVolumesSchema,
+    SimulatorFipregionsMappingSchema,
     StructureDepthFaultLinesSchema,
 ]

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -60,6 +60,7 @@ class FmuResultsSchema(SchemaBase):
       - Rft
       - Timeseries
       - Well completions
+    - Added standard result 'simulator_fipregions_mapping'.
 
     #### 0.18.0
 

--- a/src/fmu/datamodels/fmu_results/standard_result.py
+++ b/src/fmu/datamodels/fmu_results/standard_result.py
@@ -14,6 +14,7 @@ from fmu.datamodels.standard_results import (
     FieldOutlineSchema,
     FluidContactOutlineSchema,
     InplaceVolumesSchema,
+    SimulatorFipregionsMappingSchema,
     StandardResultName,
     StructureDepthFaultLinesSchema,
 )
@@ -77,6 +78,28 @@ class InplaceVolumesStandardResult(StandardResult):
         url=AnyHttpUrl(InplaceVolumesSchema.url()),
     )
     """The schema identifying the format of the 'inplace_volumes' standard result."""
+
+
+class SimulatorFipregionsMappingStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represents.
+
+    This class contains metadata for the 'simulator_fipregions_mapping'
+    standard result.
+    """
+
+    name: Literal[StandardResultName.simulator_fipregions_mapping]
+    """The identifying name for the 'simulator_fipregions_mapping' standard result."""
+
+    file_schema: FileSchema = FileSchema(
+        version=SimulatorFipregionsMappingSchema.VERSION,
+        url=AnyHttpUrl(SimulatorFipregionsMappingSchema.url()),
+    )
+    """
+    The schema identifying the format of the 'simulator_fipregions_mapping'
+    standard result.
+    """
 
 
 class StructureDepthSurfaceStandardResult(StandardResult):
@@ -275,6 +298,7 @@ class AnyStandardResult(RootModel):
         ErtParametersStandardResult
         | FieldOutlineStandardResult
         | InplaceVolumesStandardResult
+        | SimulatorFipregionsMappingStandardResult
         | StructureDepthSurfaceStandardResult
         | StructureDepthFaultSurfaceStandardResult
         | StructureTimeSurfaceStandardResult

--- a/src/fmu/datamodels/standard_results/__init__.py
+++ b/src/fmu/datamodels/standard_results/__init__.py
@@ -8,6 +8,10 @@ from .ert_parameters import (
 from .field_outline import FieldOutlineResult, FieldOutlineSchema
 from .fluid_contact_outline import FluidContactOutlineResult, FluidContactOutlineSchema
 from .inplace_volumes import InplaceVolumesResult, InplaceVolumesSchema
+from .simulator_fipregions_mapping import (
+    SimulatorFipregionsMappingResult,
+    SimulatorFipregionsMappingSchema,
+)
 from .structure_depth_fault_lines import (
     StructureDepthFaultLinesResult,
     StructureDepthFaultLinesSchema,
@@ -22,6 +26,8 @@ __all__ = [
     "FieldOutlineSchema",
     "InplaceVolumesResult",
     "InplaceVolumesSchema",
+    "SimulatorFipregionsMappingResult",
+    "SimulatorFipregionsMappingSchema",
     "StructureDepthFaultLinesSchema",
     "StructureDepthFaultLinesResult",
     "FluidContactOutlineSchema",

--- a/src/fmu/datamodels/standard_results/enums.py
+++ b/src/fmu/datamodels/standard_results/enums.py
@@ -16,6 +16,7 @@ class StandardResultName(StrEnum):
     parameters = "parameters"
     field_outline = "field_outline"
     inplace_volumes = "inplace_volumes"
+    simulator_fipregions_mapping = "simulator_fipregions_mapping"
     structure_depth_surface = "structure_depth_surface"
     structure_time_surface = "structure_time_surface"
     grid_extracted_depth_surface = "grid_extracted_depth_surface"
@@ -122,6 +123,22 @@ class FaultLines:
     def index_columns() -> list[str]:
         """Returns a list of the index columns."""
         return [k.value for k in FaultLines.TableIndexColumns]
+
+
+class SimulatorFipregionsMapping:
+    """Enumerations relevant to simulator fipregions mapping tables."""
+
+    class TableIndexColumns(StrEnum):
+        """The index columns for a simulator fipregions mapping table."""
+
+        FIPNUM = "FIPNUM"
+        ZONE = "ZONE"
+        REGION = "REGION"
+
+    @staticmethod
+    def index_columns() -> list[str]:
+        """Returns a list of the index columns."""
+        return [k.value for k in SimulatorFipregionsMapping.TableIndexColumns]
 
 
 class SimulatorTables:

--- a/src/fmu/datamodels/standard_results/simulator_fipregions_mapping.py
+++ b/src/fmu/datamodels/standard_results/simulator_fipregions_mapping.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, RootModel
+
+from fmu.datamodels._schema_base import FMU_SCHEMAS_PATH, SchemaBase
+from fmu.datamodels.types import VersionStr
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class SimulatorFipregionsMappingResultRow(BaseModel):
+    """Represents the columns of a row in a simulator fipregions mapping export.
+
+    These fields are the current agreed upon standard result. Changes to the fields or
+    their validation should cause the version defined in the standard result schema to
+    increase the version number in a way that corresponds to the schema versioning
+    specification (i.e. they are a patch, minor, or major change)."""
+
+    FIPNUM: int = Field(ge=0)
+    """Index column. The id of the fipregion this row represents. Required."""
+
+    ZONE: str
+    """Index column. The zone that the fipregion corresponds to. Required."""
+
+    REGION: str
+    """Index column. The region that the fipregion corresponds to. Required."""
+
+
+class SimulatorFipregionsMappingResult(RootModel):
+    """Represents the resultant simulator fipregions mapping parquet file, which is
+    naturally a list of rows.
+
+    Consumers who retrieve this parquet file must read it into a json-dictionary
+    equivalent format to validate it against the schema."""
+
+    root: list[SimulatorFipregionsMappingResultRow]
+
+
+class SimulatorFipregionsMappingSchema(SchemaBase):
+    """This class represents the schema that is used to validate the mapping
+    table being exported. This means that the version, schema filename, and
+    schema location corresponds directly with the values and their validation
+    constraints, documented above."""
+
+    VERSION: VersionStr = "0.1.0"
+
+    VERSION_CHANGELOG: str = """
+    #### 0.1.0
+
+    This is the initial schema version.
+    """
+
+    FILENAME: str = "simulator_fipregions_mapping.json"
+    """The filename this schema is written to."""
+
+    PATH: Path = FMU_SCHEMAS_PATH / "file_formats" / VERSION / FILENAME
+    """The local and URL path of this schema."""
+
+    @classmethod
+    def dump(cls) -> dict[str, Any]:
+        return SimulatorFipregionsMappingResult.model_json_schema(
+            schema_generator=cls.default_generator()
+        )


### PR DESCRIPTION
Resolves #153 

Adds new standard result `simulator_fipregions_mapping`  for mapping FIPNUM values to zone and region.

After more discussions we've landed on that the best solution would be to stick with FIPNUM instead of introducing a new FIPGRP parameter to be created, exported and added to the simulation DATA file.
This way the users that are already following Drogon doesn't have to add much extra to their setup. 

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅