### PR TITLE
ENH: Add known property attributes

### DIFF
--- a/schemas/0.20.0/fmu_results.json
+++ b/schemas/0.20.0/fmu_results.json
@@ -7160,6 +7160,9 @@
         "attribute": {
           "anyOf": [
             {
+              "$ref": "#/$defs/PropertyAttribute"
+            },
+            {
               "type": "string"
             },
             {
@@ -7187,6 +7190,27 @@
       },
       "title": "Property",
       "type": "object"
+    },
+    "PropertyAttribute": {
+      "description": "Known property attributes.",
+      "enum": [
+        "zonation",
+        "regions",
+        "facies",
+        "net_to_gross",
+        "fluid_indicator",
+        "porosity",
+        "permeability",
+        "permeability_vertical",
+        "saturation_water",
+        "saturation_oil",
+        "saturation_gas",
+        "volume_shale",
+        "bulk_volume_oil",
+        "bulk_volume_gas"
+      ],
+      "title": "PropertyAttribute",
+      "type": "string"
     },
     "PropertyData": {
       "description": "The ``data`` block contains information about the data contained in this object.\nThis class contains metadata for property data.",

--- a/src/fmu/datamodels/fmu_results/attribute_specification.py
+++ b/src/fmu/datamodels/fmu_results/attribute_specification.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, RootModel
+
+from . import enums
+
+
+class AttributeSpecification(BaseModel):
+    """Specifies a property attribute and its characteristics."""
+
+    attribute: enums.PropertyAttribute
+    """The name of the property attribute."""
+    is_discrete: bool
+    """Whether the property is discrete (categorical) or continuous."""
+    min_value: float | None = None
+    """Minimum value for the property, if applicable."""
+    max_value: float | None = None
+    """Maximum value for the property, if applicable."""
+
+
+class BulkVolumeGasAttributeSpecification(AttributeSpecification):
+    """Specifications related to the bulk volume gas attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.bulk_volume_gas]
+    is_discrete: bool = False
+    min_value: float = 0
+
+
+class BulkVolumeOilAttributeSpecification(AttributeSpecification):
+    """Specifications related to the bulk volume oil attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.bulk_volume_oil]
+    is_discrete: bool = False
+    min_value: float = 0
+
+
+class FaciesAttributeSpecification(AttributeSpecification):
+    """Specifications related to the facies attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.facies]
+    is_discrete: bool = True
+    min_value: float = 0
+
+
+class FluidIndicatorAttributeSpecification(AttributeSpecification):
+    """Specifications related to the fluid indicator attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.fluid_indicator]
+    is_discrete: bool = True
+    min_value: float = 0
+
+
+class NetToGrossAttributeSpecification(AttributeSpecification):
+    """Specifications related to the net-to-gross attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.net_to_gross]
+    is_discrete: bool = True
+    min_value: float = 0
+    max_value: float = 1
+
+
+class PermeabilityAttributeSpecification(AttributeSpecification):
+    """Specifications related to the permeability attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.permeability]
+    is_discrete: bool = False
+    min_value: float = 0
+
+
+class PermeabilityVerticalAttributeSpecification(AttributeSpecification):
+    """Specifications related to the vertical permeability attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.permeability_vertical]
+    is_discrete: bool = False
+    min_value: float = 0
+
+
+class PorosityAttributeSpecification(AttributeSpecification):
+    """Specifications related to the porosity attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.porosity]
+    is_discrete: bool = False
+    min_value: float = 0
+    max_value: float = 1
+
+
+class RegionsAttributeSpecification(AttributeSpecification):
+    """Specifications related to the regions attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.regions]
+    is_discrete: bool = True
+    min_value: float = 0
+
+
+class SaturationGasAttributeSpecification(AttributeSpecification):
+    """Specifications related to the gas saturation attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.saturation_gas]
+    is_discrete: bool = False
+    min_value: float = 0
+    max_value: float = 1
+
+
+class SaturationOilAttributeSpecification(AttributeSpecification):
+    """Specifications related to the oil saturation attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.saturation_oil]
+    is_discrete: bool = False
+    min_value: float = 0
+    max_value: float = 1
+
+
+class SaturationWaterAttributeSpecification(AttributeSpecification):
+    """Specifications related to the water saturation attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.saturation_water]
+    is_discrete: bool = False
+    min_value: float = 0
+    max_value: float = 1
+
+
+class VolumeShaleAttributeSpecification(AttributeSpecification):
+    """Specifications related to the volume shale attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.volume_shale]
+    is_discrete: bool = False
+    min_value: float = 0
+    max_value: float = 1
+
+
+class ZonationAttributeSpecification(AttributeSpecification):
+    """Specifications related to the zonation attribute."""
+
+    attribute: Literal[enums.PropertyAttribute.zonation]
+    is_discrete: bool = True
+    min_value: float = 0
+
+
+class AnyAttributeSpecification(RootModel):
+    """
+    Root model that allows for property attribute specifications with different
+    attribute types to be placed within it. The discriminator field is ``attribute``,
+    which indicates the specific property attribute being described.
+    """
+
+    root: Annotated[
+        BulkVolumeGasAttributeSpecification
+        | BulkVolumeOilAttributeSpecification
+        | FaciesAttributeSpecification
+        | FluidIndicatorAttributeSpecification
+        | NetToGrossAttributeSpecification
+        | PermeabilityAttributeSpecification
+        | PermeabilityVerticalAttributeSpecification
+        | PorosityAttributeSpecification
+        | RegionsAttributeSpecification
+        | SaturationGasAttributeSpecification
+        | SaturationOilAttributeSpecification
+        | SaturationWaterAttributeSpecification
+        | VolumeShaleAttributeSpecification
+        | ZonationAttributeSpecification,
+        Field(discriminator="attribute"),
+    ]

--- a/src/fmu/datamodels/fmu_results/data.py
+++ b/src/fmu/datamodels/fmu_results/data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import warnings
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 from uuid import UUID
@@ -16,6 +17,8 @@ from pydantic import (
 )
 
 from . import enums
+from .attribute_specification import AnyAttributeSpecification
+from .enums import PropertyAttribute
 from .specification import AnySpecification
 from .standard_result import AnyStandardResult
 
@@ -87,11 +90,44 @@ class Property(BaseModel):
     """A block describing property data. Shall be present if ``data.content`
     == ``property``."""
 
-    attribute: str | None = Field(default=None, examples=["porosity"])
+    attribute: PropertyAttribute | str | None = Field(
+        default=None, examples=["porosity"]
+    )
     """A known attribute."""
 
     is_discrete: bool | None = Field(default=None)
     """If True, this is a discrete property."""
+
+    @field_validator("attribute", mode="before")
+    @classmethod
+    def try_parse_property_attribute(
+        cls, v: PropertyAttribute | str | None
+    ) -> PropertyAttribute | str | None:
+        if isinstance(v, str):
+            with contextlib.suppress(ValueError):
+                return PropertyAttribute(v)
+        return v
+
+    @model_validator(mode="after")
+    def validate_is_discrete(v: Property) -> Property:
+        if isinstance(v.attribute, PropertyAttribute):
+            attr_spec = AnyAttributeSpecification.model_validate(
+                {"attribute": v.attribute}
+            ).root
+            expected_is_discrete = attr_spec.is_discrete
+
+            if v.is_discrete is not None and v.is_discrete != expected_is_discrete:
+                attr_type = "discrete" if expected_is_discrete else "continuous"
+
+                warnings.warn(
+                    f"The property attribute '{v.attribute}' is a known {attr_type} "
+                    "attribute. The 'is_discrete' field will be updated for this "
+                    "attribute. Either remove the 'is_discrete' field or update the "
+                    "value to silence this warning.",
+                )
+            v.is_discrete = expected_is_discrete
+
+        return v
 
 
 class FluidContact(BaseModel):

--- a/src/fmu/datamodels/fmu_results/enums.py
+++ b/src/fmu/datamodels/fmu_results/enums.py
@@ -391,3 +391,49 @@ class FileFormat(StrEnum):
     segy = "segy"
     openvds = "openvds"
     tsurf = "tsurf"
+
+
+class PropertyAttribute(StrEnum):
+    """Known property attributes."""
+
+    zonation = "zonation"
+    """Classification of geological zonations within the reservoir."""
+
+    regions = "regions"
+    """Classification of distinct geographic regions in the field."""
+
+    facies = "facies"
+    """Classification of rock types influencing reservoir properties."""
+
+    net_to_gross = "net_to_gross"
+    """Classification of net-to-gross ratio within the reservoir."""
+
+    fluid_indicator = "fluid_indicator"
+    """Presence indicator for specific fluids (e.g., oil/gas/water) in the reservoir."""
+
+    porosity = "porosity"
+    """The fraction of the rock volume that is pore space."""
+
+    permeability = "permeability"
+    """Measure of how easily fluids flow."""
+
+    permeability_vertical = "permeability_vertical"
+    """Measure of how easily fluids flow in the vertical direction."""
+
+    saturation_water = "saturation_water"
+    """The fraction of the pore space occupied by water."""
+
+    saturation_oil = "saturation_oil"
+    """The fraction of the pore space occupied by oil."""
+
+    saturation_gas = "saturation_gas"
+    """The fraction of the pore space occupied by gas."""
+
+    volume_shale = "volume_shale"
+    """The fraction of the rock volume that is shale."""
+
+    bulk_volume_oil = "bulk_volume_oil"
+    """The bulk volume of oil in the rock."""
+
+    bulk_volume_gas = "bulk_volume_gas"
+    """The bulk volume of gas in the rock."""

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -50,8 +50,9 @@ class FmuResultsSchema(SchemaBase):
     #### 0.20.0
 
     - Added new standard result for`grid_model_static`
+    - Added list of known property attributes
 
-     #### 0.19.0
+    #### 0.19.0
 
     - Added new standard result for`GridExtractedDepthSurfaceStandardResult`
     - Added 'mapping' as a new content type

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -529,3 +529,35 @@ def volumes_metadata() -> dict:
     return ObjectMetadata.model_validate(object_metadata_dict).model_dump(
         mode="json", exclude_none=True, by_alias=True
     )
+
+
+@pytest.fixture(scope="function")
+def property_metadata() -> dict:
+    """Generate valid property metadata"""
+
+    object_metadata_dict = _generate_object_metadata_base()
+
+    data = AnyData.model_validate(
+        {
+            "content": enums.Content.property,
+            "property": {"attribute": "porosity", "is_discrete": False},
+            "name": "phit",
+            "stratigraphic": False,
+            "format": enums.FileFormat.roff,
+            "is_observation": False,
+            "is_prediction": True,
+            "layout": enums.Layout.cornerpoint,
+            "offset": 0.0,
+            "undef_is_zero": False,
+            "unit": "m",
+            "vertical_domain": "depth",
+            "domain_reference": "msl",
+        }
+    )
+
+    object_metadata_dict["class"] = enums.ObjectMetadataClass.cpgrid_property
+    object_metadata_dict["data"] = data
+
+    return ObjectMetadata.model_validate(object_metadata_dict).model_dump(
+        mode="json", exclude_none=True, by_alias=True
+    )

--- a/tests/test_models/test_attribute_specification.py
+++ b/tests/test_models/test_attribute_specification.py
@@ -1,0 +1,43 @@
+from typing import Literal, get_args, get_origin
+
+from fmu.datamodels.fmu_results import data, enums
+from tests.utils import _get_pydantic_models_from_annotation
+
+
+def test_all_attribute_enums_in_anyattributespecification() -> None:
+    """
+    Test that all attribute enums are represented with a model
+    in AnyAttributeSpecification.
+    """
+
+    models = _get_pydantic_models_from_annotation(
+        data.AnyAttributeSpecification.model_fields["root"].annotation
+    )
+
+    enums_in_anyattributespecification = []
+    for model in models:
+        # attribute is used as a discriminator in AnyAttributeSpecification and
+        # should be present for all models
+        assert "attribute" in model.model_fields
+        attribute_annotation = model.model_fields["attribute"].annotation
+
+        # check that the annotation is a Literal
+        assert get_origin(attribute_annotation) == Literal
+
+        # get_args will unpack the enum from the Literal
+        # into a tuple, should only be one Literal value
+        assert len(get_args(attribute_annotation)) == 1
+
+        # the literal value should be an enum
+        attribute_enum = get_args(attribute_annotation)[0]
+        assert isinstance(attribute_enum, enums.PropertyAttribute)
+
+        enums_in_anyattributespecification.append(attribute_enum)
+
+    # finally check that all attribute enums are represented
+    for attribute_enum in enums.PropertyAttribute:
+        assert attribute_enum in enums_in_anyattributespecification
+
+    # and that number of models in AnyAttributeSpecification matches
+    # number of attribute enums
+    assert len(models) == len(enums.PropertyAttribute)

--- a/tests/test_models/test_data_block.py
+++ b/tests/test_models/test_data_block.py
@@ -146,6 +146,67 @@ def test_content_field_region(field_region_metadata: dict) -> None:
         FmuResults.model_validate(field_region_metadata)
 
 
+def test_content_property_known_attribute_sets_is_discrete(
+    property_metadata: dict,
+) -> None:
+    """Test is_discrete field is set for known attribute"""
+
+    # test continous attribute
+    _metadata = deepcopy(property_metadata)
+    _metadata["data"]["property"]["attribute"] = "saturation_water"
+    del _metadata["data"]["property"]["is_discrete"]
+
+    model_metadata = FmuResults.model_validate(_metadata).model_dump()
+    assert model_metadata["data"]["property"]["attribute"] == "saturation_water"
+    assert model_metadata["data"]["property"]["is_discrete"] is False
+
+    # test discrete attribute
+    _metadata = deepcopy(property_metadata)
+    _metadata["data"]["property"]["attribute"] = "regions"
+    del _metadata["data"]["property"]["is_discrete"]
+
+    model_metadata = FmuResults.model_validate(_metadata).model_dump()
+    assert model_metadata["data"]["property"]["attribute"] == "regions"
+    assert model_metadata["data"]["property"]["is_discrete"] is True
+
+
+def test_content_property_known_attribute_updates_is_discrete(
+    property_metadata: dict,
+) -> None:
+    """
+    Test is_discrete field is updated with a warning for a known attribute if an
+    incorrect is_discrete value is set.
+    """
+
+    _metadata = deepcopy(property_metadata)
+    _metadata["data"]["property"]["attribute"] = "porosity"
+    _metadata["data"]["property"]["is_discrete"] = True  # incorrect value for porosity
+
+    with pytest.warns(UserWarning, match="'is_discrete' field will be updated"):
+        model_metadata = FmuResults.model_validate(_metadata).model_dump()
+        assert model_metadata["data"]["property"]["is_discrete"] is False
+
+    _metadata = deepcopy(property_metadata)
+    _metadata["data"]["property"]["attribute"] = "facies"
+    _metadata["data"]["property"]["is_discrete"] = False  # incorrect value for facies
+
+    with pytest.warns(UserWarning, match="'is_discrete' field will be updated"):
+        model_metadata = FmuResults.model_validate(_metadata).model_dump()
+        assert model_metadata["data"]["property"]["is_discrete"] is True
+
+
+def test_content_property_unknown_attribute(property_metadata: dict) -> None:
+    """Test is_discrete field is not set for unknown attribute"""
+
+    _metadata = deepcopy(property_metadata)
+    _metadata["data"]["property"]["attribute"] = "unknown"
+    del _metadata["data"]["property"]["is_discrete"]
+
+    model_metadata = FmuResults.model_validate(_metadata).model_dump()
+    assert model_metadata["data"]["property"]["attribute"] == "unknown"
+    assert model_metadata["data"]["property"]["is_discrete"] is None
+
+
 def test_content_seismic(seismic_metadata: dict) -> None:
     """Test content-specific rule: seismic.
 


### PR DESCRIPTION
Resolves #143 

PR to start adding a list of known property attributes. It also includes a property attribute specification model where the  expected value range for the different attributes and `is_discrete` flag is specified. If the `is_discrete` flag is input by the user and it deviates with the attribute discrete value a warning is given.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅