### PR TITLE
ENH: Add value_statistics to data.spec for surfaces and properties

### DIFF
--- a/schemas/0.20.0/fmu_results.json
+++ b/schemas/0.20.0/fmu_results.json
@@ -420,6 +420,17 @@
           "exclusiveMinimum": 0,
           "title": "Nrow",
           "type": "integer"
+        },
+        "value_statistics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Statistics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
@@ -695,6 +706,17 @@
         "undef": {
           "title": "Undef",
           "type": "number"
+        },
+        "value_statistics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Statistics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "xinc": {
           "exclusiveMinimum": 0,
@@ -9532,6 +9554,35 @@
       "title": "SsdlAccess",
       "type": "object"
     },
+    "Statistics": {
+      "properties": {
+        "max": {
+          "title": "Max",
+          "type": "number"
+        },
+        "mean": {
+          "title": "Mean",
+          "type": "number"
+        },
+        "min": {
+          "title": "Min",
+          "type": "number"
+        },
+        "std": {
+          "minimum": 0,
+          "title": "Std",
+          "type": "number"
+        }
+      },
+      "required": [
+        "min",
+        "max",
+        "mean",
+        "std"
+      ],
+      "title": "Statistics",
+      "type": "object"
+    },
     "StratigraphicColumn": {
       "description": "The ``masterdata.smda.stratigraphic_column`` block contains the\nstratigraphic column known to SMDA.",
       "properties": {
@@ -10015,6 +10066,17 @@
         "undef": {
           "title": "Undef",
           "type": "number"
+        },
+        "value_statistics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Statistics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "xinc": {
           "exclusiveMinimum": 0,

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -52,6 +52,7 @@ class FmuResultsSchema(SchemaBase):
     - Added new standard result for`grid_model_static`
     - Added list of known property attributes
     - Added 'source' field in tracklog events
+    - Added optional 'value_statistics' to 'data.spec' for grid properties and surfaces.
 
     #### 0.19.0
 

--- a/src/fmu/datamodels/fmu_results/specification.py
+++ b/src/fmu/datamodels/fmu_results/specification.py
@@ -22,6 +22,20 @@ class RowColumnLayer(RowColumn):
     """The number of layers."""
 
 
+class Statistics(BaseModel):
+    min: float
+    """Minimum value"""
+
+    max: float
+    """Maximum value"""
+
+    mean: float
+    """Mean value"""
+
+    std: float = Field(ge=0)
+    """Standard deviation"""
+
+
 class SurfaceSpecification(RowColumn):
     """Specifies relevant values describing a regular surface object."""
 
@@ -45,6 +59,9 @@ class SurfaceSpecification(RowColumn):
 
     yori: float = Field(allow_inf_nan=False)
     """Origin along the y-axis."""
+
+    value_statistics: Statistics | None = Field(default=None)
+    """Statistics for the surface values."""
 
 
 # TODO: Base on TableSpecification when we only support table export format for points
@@ -132,6 +149,9 @@ class CPGridPropertySpecification(RowColumnLayer):
         default=None, examples=[{0: "shale", 1: "sand"}]
     )
     """Mapping from discrete property values to corresponding names."""
+
+    value_statistics: Statistics | None = Field(default=None)
+    """Statistics for the grid property values."""
 
 
 # TODO: Base on TableSpecification when we only support table export format for polygons

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -63,6 +63,7 @@ from fmu.datamodels.fmu_results.global_configuration import (
 )
 from fmu.datamodels.fmu_results.specification import (
     PolygonsSpecification,
+    Statistics,
     SurfaceSpecification,
     TableSpecification,
 )
@@ -295,6 +296,7 @@ def fluid_contact_metadata() -> dict:
                 xori=0.1,
                 yflip=enums.AxisOrientation.normal,
                 yori=0.1,
+                value_statistics=Statistics(min=-1.0, max=1.0, mean=0.0, std=0.5),
             ),
             "time": None,
             "undef_is_zero": None,
@@ -458,6 +460,7 @@ def seismic_metadata() -> dict:
                 xori=456063.6875,
                 yori=5926551.0,
                 yflip=enums.AxisOrientation.normal,
+                value_statistics=Statistics(min=-1.0, max=1.0, mean=0.0, std=0.5),
             ),
             "time": Time(
                 t0=Timestamp(label="base", value=datetime.datetime.now(datetime.UTC)),


### PR DESCRIPTION
Addresses https://github.com/equinor/fmu-dataio/issues/530

Add statistics of the values for grid property and surfaces. 
Keep the field optional for now to allow the surface aggregation service to test if computing these will impact performance, and implement it when/if needed by webviz. 

Corresponding implementation PR in `fmu-dataio` https://github.com/equinor/fmu-dataio/pull/1600

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅