### PR TITLE
ENH: Accept TracklogSource in tracklog init, prefer model

### DIFF
--- a/src/fmu/datamodels/__init__.py
+++ b/src/fmu/datamodels/__init__.py
@@ -2,6 +2,26 @@
 
 from fmu.datamodels._schema_base import SchemaBase
 
+from .common import (
+    Access,
+    Asset,
+    CoordinateSystem,
+    CountryItem,
+    DiscoveryItem,
+    FieldItem,
+    Masterdata,
+    OperatingSystem,
+    Smda,
+    Ssdl,
+    SsdlAccess,
+    StratigraphicColumn,
+    SystemInformation,
+    Tracklog,
+    TracklogEvent,
+    TracklogSource,
+    User,
+    Version,
+)
 from .fmu_results import FmuResults, FmuResultsSchema
 from .standard_results import (
     ErtDistribution,
@@ -28,6 +48,24 @@ except ImportError:
     __version__ = "0.0.0"
 
 __all__ = [
+    "Access",
+    "SsdlAccess",
+    "Asset",
+    "Ssdl",
+    "Masterdata",
+    "Smda",
+    "StratigraphicColumn",
+    "CoordinateSystem",
+    "CountryItem",
+    "FieldItem",
+    "DiscoveryItem",
+    "Tracklog",
+    "OperatingSystem",
+    "SystemInformation",
+    "TracklogEvent",
+    "TracklogSource",
+    "User",
+    "Version",
     "ErtDistribution",
     "ErtParameterMetadata",
     "ErtParametersResult",

--- a/src/fmu/datamodels/common/__init__.py
+++ b/src/fmu/datamodels/common/__init__.py
@@ -13,6 +13,7 @@ from .tracklog import (
     SystemInformation,
     Tracklog,
     TracklogEvent,
+    TracklogSource,
     User,
     Version,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "OperatingSystem",
     "SystemInformation",
     "TracklogEvent",
+    "TracklogSource",
     "User",
     "Version",
 ]

--- a/src/fmu/datamodels/common/tracklog.py
+++ b/src/fmu/datamodels/common/tracklog.py
@@ -54,14 +54,20 @@ class Tracklog(RootModel):
         return iter(self.root)
 
     @classmethod
-    def initialize(cls, fmu_dataio_version: str) -> Tracklog:
+    def initialize(
+        cls,
+        fmu_dataio_version: str,
+        tracklog_source: TracklogSource | None = None,
+    ) -> Tracklog:
         """Initialize the tracklog object with a list containing one
         TracklogEvent of type 'created'"""
 
         return cls(
             root=[
                 cls._generate_tracklog_event(
-                    enums.TrackLogEventType.created, fmu_dataio_version
+                    enums.TrackLogEventType.created,
+                    fmu_dataio_version,
+                    tracklog_source,
                 )
             ]
         )
@@ -70,35 +76,20 @@ class Tracklog(RootModel):
         self,
         event: enums.TrackLogEventType,
         fmu_dataio_version: str,
-        source_name: str | None = None,
-        source_version: str | None = None,
+        tracklog_source: TracklogSource | None = None,
     ) -> None:
         """Append new tracklog record to the tracklog."""
         self.root.append(
-            self._generate_tracklog_event(
-                event, fmu_dataio_version, source_name, source_version
-            )
+            self._generate_tracklog_event(event, fmu_dataio_version, tracklog_source)
         )
 
     @staticmethod
     def _generate_tracklog_event(
         event: enums.TrackLogEventType,
         version: str,
-        source_name: str | None = None,
-        source_version: str | None = None,
+        tracklog_source: TracklogSource | None = None,
     ) -> TracklogEvent:
         """Generate new tracklog event with the given event type"""
-        source: TracklogSource | None = None
-
-        if source_name is not None and source_version is not None:
-            source = TracklogSource(
-                name=source_name, version=Version(version=source_version)
-            )
-        elif source_name is not None or source_version is not None:
-            raise ValueError(
-                "Both the source name and source version must be provided together."
-            )
-
         komodo_release = os.environ.get(
             "KOMODO_RELEASE", os.environ.get("KOMODO_RELEASE_BACKUP", None)
         )
@@ -106,7 +97,7 @@ class Tracklog(RootModel):
 
         sysinfo = SystemInformation.model_construct(
             fmu_dataio=Version(version=version),
-            source=source,
+            source=tracklog_source,
             komodo=komodo,
             operating_system=OperatingSystem(
                 hostname=platform.node(),


### PR DESCRIPTION
Resolves #172 

Implementing on fmu-dataio, this seems nicer to take only the model. Also re-exports these models through the main namespace.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅