### PR TITLE
CONF: remove stickysessions property.

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -20,8 +20,6 @@ spec:
           ports:
               - name: http
                 port: 8080
-          ingressConfiguration:
-              - stickysessions
           environmentConfig:
               - environment: dev
                 horizontalScaling:


### PR DESCRIPTION
Resolves #issue

The `stickysessions` property is no longer used in radixconfug.yaml, so remove it.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅