### PR TITLE
ENH: Disallow nan values in value_statistics

### DIFF
--- a/src/fmu/datamodels/fmu_results/specification.py
+++ b/src/fmu/datamodels/fmu_results/specification.py
@@ -23,16 +23,16 @@ class RowColumnLayer(RowColumn):
 
 
 class Statistics(BaseModel):
-    min: float
+    min: float = Field(allow_inf_nan=False)
     """Minimum value"""
 
-    max: float
+    max: float = Field(allow_inf_nan=False)
     """Maximum value"""
 
-    mean: float
+    mean: float = Field(allow_inf_nan=False)
     """Mean value"""
 
-    std: float = Field(ge=0)
+    std: float = Field(ge=0, allow_inf_nan=False)
     """Standard deviation"""
 
 


### PR DESCRIPTION
`Nan` values can not be converted to json, hence add extra requirements of the fields in the `value_statistics` to ensure they are not `nan.` 

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅