### PR TITLE
ENH: Add standard results for Ert observations rft and summary

### DIFF
--- a/schemas/0.21.0/fmu_results.json
+++ b/schemas/0.21.0/fmu_results.json
@@ -226,6 +226,12 @@
       },
       "oneOf": [
         {
+          "$ref": "#/$defs/ErtObservationsRftStandardResult"
+        },
+        {
+          "$ref": "#/$defs/ErtObservationsSummaryStandardResult"
+        },
+        {
           "$ref": "#/$defs/ErtParametersStandardResult"
         },
         {
@@ -1291,6 +1297,50 @@
         "simulation_mode"
       ],
       "title": "Ert",
+      "type": "object"
+    },
+    "ErtObservationsRftStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represents.\n\nThis class contains metadata for the 'observations_rft' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/ert_observations_rft.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "observations_rft",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ErtObservationsRftStandardResult",
+      "type": "object"
+    },
+    "ErtObservationsSummaryStandardResult": {
+      "description": "The ``standard_result`` field contains information about which standard results this\ndata object represents.\n\nThis class contains metadata for the 'observations_summary' standard result.",
+      "properties": {
+        "file_schema": {
+          "$ref": "#/$defs/FileSchema",
+          "default": {
+            "url": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/ert_observations_summary.json",
+            "version": "0.1.0"
+          }
+        },
+        "name": {
+          "const": "observations_summary",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ErtObservationsSummaryStandardResult",
       "type": "object"
     },
     "ErtParametersStandardResult": {

--- a/schemas/file_formats/0.1.0/ert_observations_rft.json
+++ b/schemas/file_formats/0.1.0/ert_observations_rft.json
@@ -1,0 +1,91 @@
+{
+  "$defs": {
+    "ErtObservationsRftResultRow": {
+      "description": "Represents the columns of a row in a Ert rft observation export.\n\nThese fields are the current agreed upon standard result. Changes to the fields or\ntheir validation should cause the version defined in the standard result schema to\nincrease the version number in a way that corresponds to the schema versioning\nspecification (i.e. they are a patch, minor, or major change).",
+      "properties": {
+        "date": {
+          "title": "Date",
+          "type": "string"
+        },
+        "east": {
+          "title": "East",
+          "type": "number"
+        },
+        "md": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Md"
+        },
+        "north": {
+          "title": "North",
+          "type": "number"
+        },
+        "observation_error": {
+          "title": "Observation Error",
+          "type": "number"
+        },
+        "observation_value": {
+          "title": "Observation Value",
+          "type": "number"
+        },
+        "property": {
+          "title": "Property",
+          "type": "string"
+        },
+        "response_key": {
+          "title": "Response Key",
+          "type": "string"
+        },
+        "tvd": {
+          "title": "Tvd",
+          "type": "number"
+        },
+        "well": {
+          "title": "Well",
+          "type": "string"
+        },
+        "zone": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Zone"
+        }
+      },
+      "required": [
+        "response_key",
+        "property",
+        "well",
+        "date",
+        "observation_value",
+        "observation_error",
+        "east",
+        "north",
+        "tvd"
+      ],
+      "title": "ErtObservationsRftResultRow",
+      "type": "object"
+    }
+  },
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/ert_observations_rft.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Represents the resultant Ert rft observations parquet file, which is\nnaturally a list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
+  "items": {
+    "$ref": "#/$defs/ErtObservationsRftResultRow"
+  },
+  "title": "ErtObservationsRftResult",
+  "type": "array",
+  "version": "0.1.0"
+}

--- a/schemas/file_formats/0.1.0/ert_observations_summary.json
+++ b/schemas/file_formats/0.1.0/ert_observations_summary.json
@@ -1,0 +1,67 @@
+{
+  "$defs": {
+    "ErtObservationsSummaryResultRow": {
+      "description": "Represents the columns of a row in a Ert summary observation export.\n\nThese fields are the current agreed upon standard result. Changes to the fields or\ntheir validation should cause the version defined in the standard result schema to\nincrease the version number in a way that corresponds to the schema versioning\nspecification (i.e. they are a patch, minor, or major change).",
+      "properties": {
+        "east": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "East"
+        },
+        "north": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "North"
+        },
+        "observation_error": {
+          "title": "Observation Error",
+          "type": "number"
+        },
+        "observation_value": {
+          "title": "Observation Value",
+          "type": "number"
+        },
+        "response_key": {
+          "title": "Response Key",
+          "type": "string"
+        },
+        "time": {
+          "format": "date-time",
+          "title": "Time",
+          "type": "string"
+        }
+      },
+      "required": [
+        "response_key",
+        "time",
+        "observation_value",
+        "observation_error"
+      ],
+      "title": "ErtObservationsSummaryResultRow",
+      "type": "object"
+    }
+  },
+  "$id": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/file_formats/0.1.0/ert_observations_summary.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Represents the resultant Ert summary observations parquet file, which is\nnaturally a list of rows.\n\nConsumers who retrieve this parquet file must read it into a json-dictionary\nequivalent format to validate it against the schema.",
+  "items": {
+    "$ref": "#/$defs/ErtObservationsSummaryResultRow"
+  },
+  "title": "ErtObservationsSummaryResult",
+  "type": "array",
+  "version": "0.1.0"
+}

--- a/src/fmu/datamodels/__init__.py
+++ b/src/fmu/datamodels/__init__.py
@@ -25,6 +25,10 @@ from .common import (
 from .fmu_results import FmuResults, FmuResultsSchema
 from .standard_results import (
     ErtDistribution,
+    ErtObservationsRftResult,
+    ErtObservationsRftSchema,
+    ErtObservationsSummaryResult,
+    ErtObservationsSummarySchema,
     ErtParameterMetadata,
     ErtParametersResult,
     ErtParametersSchema,
@@ -67,6 +71,10 @@ __all__ = [
     "User",
     "Version",
     "ErtDistribution",
+    "ErtObservationsRftResult",
+    "ErtObservationsRftSchema",
+    "ErtObservationsSummaryResult",
+    "ErtObservationsSummarySchema",
     "ErtParameterMetadata",
     "ErtParametersResult",
     "ErtParametersSchema",
@@ -86,6 +94,8 @@ __all__ = [
 
 schemas: list[type[SchemaBase]] = [
     FmuResultsSchema,
+    ErtObservationsRftSchema,
+    ErtObservationsSummarySchema,
     ErtParametersSchema,
     FieldOutlineSchema,
     FluidContactOutlineSchema,

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -50,6 +50,8 @@ class FmuResultsSchema(SchemaBase):
     #### 0.21.0
 
     - Added `observations` as new content type
+    - Added 'observations_rft' standard result for Ert rft observations.
+    - Added 'observations_summary' standard result for Ert summary observations.
 
     #### 0.20.0
 

--- a/src/fmu/datamodels/fmu_results/standard_result.py
+++ b/src/fmu/datamodels/fmu_results/standard_result.py
@@ -18,6 +18,12 @@ from fmu.datamodels.standard_results import (
     StandardResultName,
     StructureDepthFaultLinesSchema,
 )
+from fmu.datamodels.standard_results.ert_observations_rft import (
+    ErtObservationsRftSchema,
+)
+from fmu.datamodels.standard_results.ert_observations_summary import (
+    ErtObservationsSummarySchema,
+)
 from fmu.datamodels.types import VersionStr
 
 
@@ -42,6 +48,45 @@ class StandardResult(BaseModel):
 
     file_schema: FileSchema | None = Field(default=None)
     """The schema identifying the format of the standard result."""
+
+
+class ErtObservationsRftStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represents.
+
+    This class contains metadata for the 'observations_rft' standard result.
+    """
+
+    name: Literal[StandardResultName.observations_rft]
+    """The identifying name for the 'observations_rft' standard result."""
+
+    file_schema: FileSchema = FileSchema(
+        version=ErtObservationsRftSchema.VERSION,
+        url=AnyHttpUrl(ErtObservationsRftSchema.url()),
+    )
+    """The schema identifying the format of the 'observations_rft' standard result."""
+
+
+class ErtObservationsSummaryStandardResult(StandardResult):
+    """
+    The ``standard_result`` field contains information about which standard results this
+    data object represents.
+
+    This class contains metadata for the 'observations_summary' standard result.
+    """
+
+    name: Literal[StandardResultName.observations_summary]
+    """The identifying name for the 'observations_summary' standard result."""
+
+    file_schema: FileSchema = FileSchema(
+        version=ErtObservationsSummarySchema.VERSION,
+        url=AnyHttpUrl(ErtObservationsSummarySchema.url()),
+    )
+    """
+    The schema identifying the format of the 'observations_summary' standard
+    result.
+    """
 
 
 class ErtParametersStandardResult(StandardResult):
@@ -306,7 +351,9 @@ class AnyStandardResult(RootModel):
     """
 
     root: Annotated[
-        ErtParametersStandardResult
+        ErtObservationsRftStandardResult
+        | ErtObservationsSummaryStandardResult
+        | ErtParametersStandardResult
         | FieldOutlineStandardResult
         | InplaceVolumesStandardResult
         | SimulatorFipregionsMappingStandardResult

--- a/src/fmu/datamodels/standard_results/__init__.py
+++ b/src/fmu/datamodels/standard_results/__init__.py
@@ -1,4 +1,12 @@
 from .enums import StandardResultName
+from .ert_observations_rft import (
+    ErtObservationsRftResult,
+    ErtObservationsRftSchema,
+)
+from .ert_observations_summary import (
+    ErtObservationsSummaryResult,
+    ErtObservationsSummarySchema,
+)
 from .ert_parameters import (
     ErtDistribution,
     ErtParameterMetadata,
@@ -19,6 +27,10 @@ from .structure_depth_fault_lines import (
 
 __all__ = [
     "ErtDistribution",
+    "ErtObservationsRftResult",
+    "ErtObservationsRftSchema",
+    "ErtObservationsSummaryResult",
+    "ErtObservationsSummarySchema",
     "ErtParameterMetadata",
     "ErtParametersResult",
     "ErtParametersSchema",

--- a/src/fmu/datamodels/standard_results/enums.py
+++ b/src/fmu/datamodels/standard_results/enums.py
@@ -14,6 +14,8 @@ class StandardResultName(StrEnum):
     """The standard result name of a given data object."""
 
     parameters = "parameters"
+    observations_summary = "observations_summary"
+    observations_rft = "observations_rft"
     field_outline = "field_outline"
     inplace_volumes = "inplace_volumes"
     simulator_fipregions_mapping = "simulator_fipregions_mapping"
@@ -124,6 +126,25 @@ class FaultLines:
     def index_columns() -> list[str]:
         """Returns a list of the index columns."""
         return [k.value for k in FaultLines.TableIndexColumns]
+
+
+class ErtObservations:
+    """Enumerations relevant to observations tables extracted from Ert storage."""
+
+    class RftColumns(IndexColumnsStrEnum):
+        """The index columns for a rft observations table."""
+
+        response_key = "response_key"
+        property = "property"
+        well = "well"
+        date = "date"
+        zone = "zone"
+
+    class SummaryColumns(IndexColumnsStrEnum):
+        """The index columns for a summary observations table."""
+
+        response_key = "response_key"
+        time = "time"
 
 
 class SimulatorFipregionsMapping:

--- a/src/fmu/datamodels/standard_results/ert_observations_rft.py
+++ b/src/fmu/datamodels/standard_results/ert_observations_rft.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, RootModel
+
+from fmu.datamodels._schema_base import FMU_SCHEMAS_PATH, SchemaBase
+from fmu.datamodels.types import VersionStr
+
+
+class ErtObservationsRftResultRow(BaseModel):
+    """Represents the columns of a row in a Ert rft observation export.
+
+    These fields are the current agreed upon standard result. Changes to the fields or
+    their validation should cause the version defined in the standard result schema to
+    increase the version number in a way that corresponds to the schema versioning
+    specification (i.e. they are a patch, minor, or major change)."""
+
+    response_key: str
+    """The response key this row represents. Required."""
+
+    property: str
+    """The property this row represents, e.g. 'PRESSURE' or 'SWAT'. Required."""
+
+    well: str
+    """The well this row represents. Required."""
+
+    date: str
+    """The date in ISO 8601 format this row represents. Required."""
+
+    observation_value: float
+    """The observation value this row represents. Required."""
+
+    observation_error: float
+    """The observation error in std this row represents. Required."""
+
+    east: float
+    """The east coordinate this row represents. Required."""
+
+    north: float
+    """The north coordinate this row represents. Required."""
+
+    tvd: float
+    """The depth coordinate this row represents. Required."""
+
+    zone: str | None = Field(default=None)
+    """The zone this row represents. Optional."""
+
+    md: float | None = Field(default=None)
+    """The measured depth along the well this row represents. Optional."""
+
+
+class ErtObservationsRftResult(RootModel):
+    """Represents the resultant Ert rft observations parquet file, which is
+    naturally a list of rows.
+
+    Consumers who retrieve this parquet file must read it into a json-dictionary
+    equivalent format to validate it against the schema."""
+
+    root: list[ErtObservationsRftResultRow]
+
+
+class ErtObservationsRftSchema(SchemaBase):
+    """This class represents the schema that is used to validate the Ert rft
+    observations table being exported. This means that the version, schema filename,
+    and schema location corresponds directly with the values and their validation
+    constraints, documented above."""
+
+    VERSION: VersionStr = "0.1.0"
+    """The version of this schema."""
+
+    VERSION_CHANGELOG: str = """
+    #### 0.1.0
+
+    This is the initial schema version.
+    """
+
+    FILENAME: str = "ert_observations_rft.json"
+    """The filename this schema is written to."""
+
+    PATH: Path = FMU_SCHEMAS_PATH / "file_formats" / VERSION / FILENAME
+    """The local and URL path of this schema."""
+
+    @classmethod
+    def dump(cls) -> dict[str, Any]:
+        return ErtObservationsRftResult.model_json_schema(
+            schema_generator=cls.default_generator()
+        )

--- a/src/fmu/datamodels/standard_results/ert_observations_summary.py
+++ b/src/fmu/datamodels/standard_results/ert_observations_summary.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, RootModel
+
+from fmu.datamodels._schema_base import FMU_SCHEMAS_PATH, SchemaBase
+from fmu.datamodels.types import VersionStr
+
+
+class ErtObservationsSummaryResultRow(BaseModel):
+    """Represents the columns of a row in a Ert summary observation export.
+
+    These fields are the current agreed upon standard result. Changes to the fields or
+    their validation should cause the version defined in the standard result schema to
+    increase the version number in a way that corresponds to the schema versioning
+    specification (i.e. they are a patch, minor, or major change)."""
+
+    response_key: str
+    """The response key this row represents. Required."""
+
+    time: datetime
+    """The datetime in millisecond precision this row represents. Required."""
+
+    observation_value: float
+    """The observation value this row represents. Required."""
+
+    observation_error: float
+    """The observation error in std this row represents. Required."""
+
+    east: float | None = Field(default=None)
+    """The east coordinate this row represents. Optional."""
+
+    north: float | None = Field(default=None)
+    """The north coordinate this row represents. Optional."""
+
+
+class ErtObservationsSummaryResult(RootModel):
+    """Represents the resultant Ert summary observations parquet file, which is
+    naturally a list of rows.
+
+    Consumers who retrieve this parquet file must read it into a json-dictionary
+    equivalent format to validate it against the schema."""
+
+    root: list[ErtObservationsSummaryResultRow]
+
+
+class ErtObservationsSummarySchema(SchemaBase):
+    """This class represents the schema that is used to validate the Ert summary
+    observations table being exported. This means that the version, schema filename,
+    and schema location corresponds directly with the values and their validation
+    constraints, documented above."""
+
+    VERSION: VersionStr = "0.1.0"
+    """The version of this schema."""
+
+    VERSION_CHANGELOG: str = """
+    #### 0.1.0
+
+    This is the initial schema version.
+    """
+
+    FILENAME: str = "ert_observations_summary.json"
+    """The filename this schema is written to."""
+
+    PATH: Path = FMU_SCHEMAS_PATH / "file_formats" / VERSION / FILENAME
+    """The local and URL path of this schema."""
+
+    @classmethod
+    def dump(cls) -> dict[str, Any]:
+        return ErtObservationsSummaryResult.model_json_schema(
+            schema_generator=cls.default_generator()
+        )


### PR DESCRIPTION
Resolves #193 

PR to add two new standard results for ert observations, `observations_rft` and `observations_summary`.

The table definitions are primarily taken from the table that is fetched from the ert storage. But some modifications where done:
- renamed `observations` to `observation_value` 
- renamed `std` to `observation_error`
- added `property` - now embedded in the response_key string, but should exist as separate column
- removed `observation_key` - there is no value in this and ert will remove it
- removed `radius` - there will be changes from ert here, can re-add when/if needed 
 
## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅