### PR TITLE
ENH: Remove equivalent and add unmappable relation type in Mappings

### DIFF
--- a/src/fmu/datamodels/context/mappings.py
+++ b/src/fmu/datamodels/context/mappings.py
@@ -56,10 +56,10 @@ class BaseMapping(BaseModel):
 
     @model_validator(mode="after")
     def validate_relation_system_constraints(self) -> "BaseMapping":
-        """Validate which relation types are allowed for same vs cross-system rows.
+        """Validate which relation types are allowed for same vs cross-system mappings.
 
-        Same-system rows can only be ``primary`` or ``alias``.
-        Cross-system rows can only be ``primary`` or ``unmappable``.
+        Same-system mappings can only be ``primary`` or ``alias``.
+        Cross-system mappings can only be ``primary`` or ``unmappable``.
         """
 
         if self.source_system == self.target_system:
@@ -109,11 +109,11 @@ class IdentifierMapping(BaseMapping):
         """Validate how ``source_id`` and ``target_id`` are allowed to relate.
 
         This means:
-        - ``unmappable`` rows must leave the target empty
-        - all other rows must provide a target
-        - same-system ``primary`` rows must use the same ``source_id`` and
+        - ``unmappable`` mappings must leave the target empty
+        - all other mappings must provide a target
+        - same-system ``primary`` mappings must use the same ``source_id`` and
           ``target_id``
-        - same-system ``alias`` rows must point to a different same-system
+        - same-system ``alias`` mappings must point to a different same-system
           ``target_id``
         """
         if self.relation_type == RelationType.unmappable:
@@ -178,52 +178,53 @@ AnyIdentifierMapping = Annotated[
 def _validate_identifier_mappings_collection(
     mappings: Sequence[IdentifierMapping],
 ) -> None:
-    """Validate how mapping rows are allowed to fit together.
+    """Validate how mappings are allowed to fit together.
 
     The collection must satisfy three invariants:
 
     - A same-system ``source_id`` can appear only once per mapping type.
-      Example valid rows::
+      Example valid mappings::
 
           rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
           rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
 
-      Example invalid rows::
+      Example invalid mappings::
 
           rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
           rms -> rms, alias, source_id="TopVolantis", target_id="TopVolon"
 
-      The second row is invalid because ``TopVolantis`` is reused as a same-system
-      ``source_id``.
+      The second mapping is invalid because ``TopVolantis`` is reused as a
+      same-system ``source_id``.
 
-    - Same-system alias rows must point to an existing same-system primary row.
-      Example valid rows::
+    - Same-system alias mappings must point to an existing same-system primary
+      mapping.
+      Example valid mappings::
 
           rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
           rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
 
-      Example invalid row::
+      Example invalid mapping::
 
           rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
 
-      The alias is invalid on its own because there is no same-system primary row
-      for ``TopVolantis``.
+      The alias is invalid on its own because there is no same-system primary
+      mapping for ``TopVolantis``.
 
-    - Cross-system rows must originate from a same-system primary row and can
-      appear only once per target system.
-      Example valid rows::
+    - Cross-system mappings must originate from a same-system primary mapping and
+      can appear only once per target system.
+      Example valid mappings::
 
           rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
           rms -> smda, primary, source_id="TopVolantis", target_id="VOLANTIS GP. Top"
 
-      Example invalid rows::
+      Example invalid mappings::
 
           rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
           rms -> smda, primary, source_id="TOP_VOLANTIS", target_id="VOLANTIS GP. Top"
 
-      The cross-system row is invalid because it starts from an alias instead of a
-      same-system primary. It is also invalid to add two ``rms -> smda`` rows for
-      the same ``source_id``.
+      The cross-system mapping is invalid because it starts from an alias instead
+      of a same-system primary. It is also invalid to add two ``rms -> smda``
+      mappings for the same ``source_id``.
     """
     same_system_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
     same_system_primary_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
@@ -240,8 +241,8 @@ def _validate_identifier_mappings_collection(
             mapping.source_id,
         )
 
-        # Same-system rows tell us which source_id is the main one and which
-        # source_ids are aliases of that main one.
+        # Same-system mappings tell us which source_id is the primary and which
+        # source_ids are aliases of that primary.
         if mapping.source_system == mapping.target_system:
             if source_key in same_system_source_keys:
                 raise ValueError("Same-system mappings cannot reuse the same source_id")
@@ -283,7 +284,7 @@ def _validate_identifier_mappings_collection(
                 "same-system primary source_id"
             )
 
-    # Cross-system rows are only allowed when they start from a same-system
+    # Cross-system mappings are only allowed when they start from a same-system
     # primary source_id.
     for mapping in cross_system_mappings:
         primary_source_key = (

--- a/src/fmu/datamodels/context/mappings.py
+++ b/src/fmu/datamodels/context/mappings.py
@@ -23,16 +23,16 @@ class RelationType(StrEnum):
     """The kind of relation this mapping represents."""
 
     primary = "primary"
-    """The primary unofficial identifier."""
+    """The main source identifier to use for this mapping."""
 
     alias = "alias"
-    """Alias of a primary unofficial identifier."""
+    """Alias of a primary identifier."""
 
     unmappable = "unmappable"
     """A source identifier that has been reviewed and cannot be mapped.
 
-    This relation records the intended source and target systems, but there is no
-    corresponding identifier in the target system.
+    This means the identifier has been checked, but no matching identifier exists
+    in the target system.
     """
 
 

--- a/src/fmu/datamodels/context/mappings.py
+++ b/src/fmu/datamodels/context/mappings.py
@@ -1,6 +1,6 @@
 """Data mapping models between systems."""
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from enum import StrEnum
 from typing import Annotated, Literal, Self
 from uuid import UUID
@@ -55,21 +55,23 @@ class BaseMapping(BaseModel):
     relation_type: RelationType
 
     @model_validator(mode="after")
-    def validate_systems_differ(self) -> "BaseMapping":
-        """Ensure source and target systems are different.
+    def validate_relation_system_constraints(self) -> "BaseMapping":
+        """Validate which relation types are allowed for same vs cross-system rows.
 
-        Mappings between FMU sources are allowed.
+        Same-system rows can only be ``primary`` or ``alias``.
+        Cross-system rows can only be ``primary`` or ``unmappable``.
         """
 
         if self.source_system == self.target_system:
-            # Allow FMU to map to FMU.
-            if self.source_system == DataSystem.fmu:
-                return self
+            if self.relation_type == RelationType.unmappable:
+                raise ValueError(
+                    "Same-system mapping cannot use relation_type 'unmappable'"
+                )
+            return self
 
-            raise ValueError(
-                f"source_system and target_system must differ, "
-                f"both are '{self.source_system}'"
-            )
+        if self.relation_type == RelationType.alias:
+            raise ValueError("Cross-system mapping cannot use relation_type 'alias'")
+
         return self
 
 
@@ -104,7 +106,16 @@ class IdentifierMapping(BaseMapping):
 
     @model_validator(mode="after")
     def validate_relation_target_constraints(self) -> Self:
-        """Ensure relation-specific target identifier constraints are respected."""
+        """Validate how ``source_id`` and ``target_id`` are allowed to relate.
+
+        This means:
+        - ``unmappable`` rows must leave the target empty
+        - all other rows must provide a target
+        - same-system ``primary`` rows must use the same ``source_id`` and
+          ``target_id``
+        - same-system ``alias`` rows must point to a different same-system
+          ``target_id``
+        """
         if self.relation_type == RelationType.unmappable:
             if self.target_id is not None or self.target_uuid is not None:
                 raise ValueError(
@@ -116,6 +127,26 @@ class IdentifierMapping(BaseMapping):
             raise ValueError(
                 "target_id is required unless relation_type is 'unmappable'"
             )
+
+        if self.source_system == self.target_system:
+            if self.relation_type == RelationType.primary:
+                if self.source_id != self.target_id:
+                    raise ValueError(
+                        "Same-system primary mapping must have matching "
+                        "source_id and target_id; use relation_type='alias' "
+                        "if they should differ"
+                    )
+                return self
+
+            if self.relation_type == RelationType.alias:
+                if self.source_id == self.target_id:
+                    raise ValueError(
+                        "Same-system alias mapping must have different "
+                        "source_id and target_id; use relation_type='primary' "
+                        "if they should match"
+                    )
+                return self
+
         return self
 
 
@@ -144,10 +175,139 @@ AnyIdentifierMapping = Annotated[
 ]
 
 
+def _validate_identifier_mappings_collection(
+    mappings: Sequence[IdentifierMapping],
+) -> None:
+    """Validate how mapping rows are allowed to fit together.
+
+    The collection must satisfy three invariants:
+
+    - A same-system ``source_id`` can appear only once per mapping type.
+      Example valid rows::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+
+      Example invalid rows::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> rms, alias, source_id="TopVolantis", target_id="TopVolon"
+
+      The second row is invalid because ``TopVolantis`` is reused as a same-system
+      ``source_id``.
+
+    - Same-system alias rows must point to an existing same-system primary row.
+      Example valid rows::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+
+      Example invalid row::
+
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+
+      The alias is invalid on its own because there is no same-system primary row
+      for ``TopVolantis``.
+
+    - Cross-system rows must originate from a same-system primary row and can
+      appear only once per target system.
+      Example valid rows::
+
+          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
+          rms -> smda, primary, source_id="TopVolantis", target_id="VOLANTIS GP. Top"
+
+      Example invalid rows::
+
+          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
+          rms -> smda, primary, source_id="TOP_VOLANTIS", target_id="VOLANTIS GP. Top"
+
+      The cross-system row is invalid because it starts from an alias instead of a
+      same-system primary. It is also invalid to add two ``rms -> smda`` rows for
+      the same ``source_id``.
+    """
+    same_system_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
+    same_system_primary_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
+    same_system_aliases: list[IdentifierMapping] = []
+    cross_system_source_keys: set[tuple[MappingType, DataSystem, DataSystem, str]] = (
+        set()
+    )
+    cross_system_mappings: list[IdentifierMapping] = []
+
+    for mapping in mappings:
+        source_key = (
+            mapping.source_system,
+            mapping.mapping_type,
+            mapping.source_id,
+        )
+
+        # Same-system rows tell us which source_id is the main one and which
+        # source_ids are aliases of that main one.
+        if mapping.source_system == mapping.target_system:
+            if source_key in same_system_source_keys:
+                raise ValueError("Same-system mappings cannot reuse the same source_id")
+            same_system_source_keys.add(source_key)
+
+            if mapping.relation_type == RelationType.primary:
+                same_system_primary_source_keys.add(source_key)
+            else:
+                same_system_aliases.append(mapping)
+            continue
+
+        # A source_id can map to each target system only once.
+        cross_system_key = (
+            mapping.mapping_type,
+            mapping.source_system,
+            mapping.target_system,
+            mapping.source_id,
+        )
+        if cross_system_key in cross_system_source_keys:
+            raise ValueError(
+                "A source_id can only have one cross-system mapping per target system"
+            )
+        cross_system_source_keys.add(cross_system_key)
+        cross_system_mappings.append(mapping)
+
+    # Every alias must point to a same-system primary source_id that already
+    # exists in the collection.
+    for mapping in same_system_aliases:
+        primary_target_id = mapping.target_id
+        assert primary_target_id is not None
+        primary_target_key = (
+            mapping.source_system,
+            mapping.mapping_type,
+            primary_target_id,
+        )
+        if primary_target_key not in same_system_primary_source_keys:
+            raise ValueError(
+                "Same-system alias mappings must point to an existing "
+                "same-system primary source_id"
+            )
+
+    # Cross-system rows are only allowed when they start from a same-system
+    # primary source_id.
+    for mapping in cross_system_mappings:
+        primary_source_key = (
+            mapping.source_system,
+            mapping.mapping_type,
+            mapping.source_id,
+        )
+        if primary_source_key not in same_system_primary_source_keys:
+            raise ValueError(
+                "Cross-system mappings must use a source_id that is defined "
+                "as a same-system primary"
+            )
+
+
 class StratigraphyMappings(RootModel[list[StratigraphyIdentifierMapping]]):
     """Collection of all stratigraphy mappings."""
 
     root: list[StratigraphyIdentifierMapping]
+
+    @model_validator(mode="after")
+    def validate_collection(self) -> Self:
+        """Ensure the mapping collection follows the allowed mapping rules."""
+        _validate_identifier_mappings_collection(self.root)
+        return self
 
     def __getitem__(self: Self, index: int) -> StratigraphyIdentifierMapping:
         """Retrieves a stratigraphy mapping from the list using the specified index."""
@@ -163,54 +323,20 @@ class StratigraphyMappings(RootModel[list[StratigraphyIdentifierMapping]]):
         """Returns the number of stratigraphy mappings."""
         return len(self.root)
 
-    def get_by_source(
-        self, source_id: str, source_system: DataSystem = DataSystem.rms
-    ) -> list[StratigraphyIdentifierMapping]:
-        """Get all stratigraphy mappings from a source identifier."""
-        return [
-            m
-            for m in self.root
-            if m.source_id == source_id and m.source_system == source_system
-        ]
-
-    def get_by_target(
-        self,
-        target_id: str,
-        target_system: DataSystem = DataSystem.smda,
-    ) -> list[StratigraphyIdentifierMapping]:
-        """Get all stratigraphy mappings to a target identifier."""
-        return [
-            m
-            for m in self.root
-            if m.target_id == target_id and m.target_system == target_system
-        ]
-
-    def get_official_name(
-        self,
-        rms_name: str,
-    ) -> str | None:
-        """Get the official SMDA name for an RMS stratigraphy identifier.
-
-        Args:
-            rms_name: The RMS name
-
-        Returns:
-            The official SMDA name, or None if not found
-        """
-        mappings = [
-            m
-            for m in self.root
-            if m.source_id == rms_name
-            and m.source_system == DataSystem.rms
-            and m.target_system == DataSystem.smda
-        ]
-        return mappings[0].target_id if mappings else None
-
 
 class WellboreMappings(RootModel[list[WellboreIdentifierMapping]]):
     """Collection of all wellbore mappings."""
 
     root: list[WellboreIdentifierMapping]
+
+    @model_validator(mode="after")
+    def validate_collection(self) -> Self:
+        """Ensure the mapping collection follows the allowed mapping rules."""
+        # Wellbore mappings are not expected to use aliases today, but reusing the
+        # shared identifier-mapping rules keeps the validation consistent if that
+        # changes later.
+        _validate_identifier_mappings_collection(self.root)
+        return self
 
     def __getitem__(self: Self, index: int) -> WellboreIdentifierMapping:
         """Retrieves a wellbore mapping from the list using the specified index."""

--- a/src/fmu/datamodels/context/mappings.py
+++ b/src/fmu/datamodels/context/mappings.py
@@ -28,10 +28,12 @@ class RelationType(StrEnum):
     alias = "alias"
     """Alias of a primary unofficial identifier."""
 
-    equivalent = "equivalent"
-    """A name used in the source system that is the same as the official name.
+    unmappable = "unmappable"
+    """A source identifier that has been reviewed and cannot be mapped.
 
-    For example, if an RMS stratigraphic name is the same as the SMDA name."""
+    This relation records the intended source and target systems, but there is no
+    corresponding identifier in the target system.
+    """
 
 
 class DataSystem(StrEnum):
@@ -81,26 +83,38 @@ class IdentifierMapping(BaseMapping):
 
     source_id: str
     source_uuid: UUID | None = None
-    target_id: str
+    target_id: str | None = None
     target_uuid: UUID | None = None
 
-    @field_validator("source_id", "target_id")
-    def validate_ids_not_empty(cls: Self, v: str) -> str:
-        """Ensure IDs are not empty strings."""
+    @field_validator("source_id")
+    def validate_source_id_not_empty(cls: Self, v: str) -> str:
+        """Ensure source IDs are not empty strings."""
         if not v or not v.strip():
             raise ValueError("An identifier cannot be an empty string")
         return v.strip()
 
+    @field_validator("target_id")
+    def validate_target_id_not_empty(cls: Self, v: str | None) -> str | None:
+        """Ensure target IDs are not empty strings when provided."""
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("An identifier cannot be an empty string")
+        return v.strip()
+
     @model_validator(mode="after")
-    def validate_equivalent_relation(self) -> Self:
-        """Ensure relation_type=equivalent is only used when source and target match."""
-        if (
-            self.relation_type == RelationType.equivalent
-            and self.source_id != self.target_id
-        ):
+    def validate_relation_target_constraints(self) -> Self:
+        """Ensure relation-specific target identifier constraints are respected."""
+        if self.relation_type == RelationType.unmappable:
+            if self.target_id is not None or self.target_uuid is not None:
+                raise ValueError(
+                    "Unmappable mapping cannot define target_id or target_uuid"
+                )
+            return self
+
+        if self.target_id is None:
             raise ValueError(
-                "Equivalent mapping requires matching source_id/target_id; "
-                f"got source_id='{self.source_id}', target_id='{self.target_id}'"
+                "target_id is required unless relation_type is 'unmappable'"
             )
         return self
 

--- a/tests/test_models/test_mappings.py
+++ b/tests/test_models/test_mappings.py
@@ -52,16 +52,69 @@ def test_identifier_mapping_ids_not_empty_strings() -> None:
         )
 
 
-def test_identifiers_equivalent_if_relation_equivalent() -> None:
-    """Validation fails if the relation type is equivalent but identifiers are not."""
-    with pytest.raises(ValueError, match="Equivalent mapping requires"):
+def test_identifier_mapping_allows_unmappable_without_target() -> None:
+    """An unmappable relation can omit target identifier fields."""
+    mapping = IdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        mapping_type=MappingType.stratigraphy,
+        relation_type=RelationType.unmappable,
+        source_id="NoMatch",
+    )
+
+    assert mapping.target_id is None
+    assert mapping.target_uuid is None
+
+
+def test_identifier_mapping_allows_explicit_none_target_for_unmappable() -> None:
+    """An unmappable relation also accepts an explicit null target identifier."""
+    mapping = IdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        mapping_type=MappingType.stratigraphy,
+        relation_type=RelationType.unmappable,
+        source_id="NoMatch",
+        target_id=None,
+    )
+
+    assert mapping.target_id is None
+
+
+def test_identifier_mapping_rejects_blank_target_id() -> None:
+    """Target identifiers cannot be blank when provided."""
+    with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
         IdentifierMapping(
             source_system=DataSystem.rms,
-            target_system=DataSystem.fmu,
+            target_system=DataSystem.smda,
             mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.equivalent,
-            source_id="bar",
-            target_id="foo",
+            relation_type=RelationType.primary,
+            source_id="TopVolantis",
+            target_id="   ",
+        )
+
+
+def test_identifier_mapping_requires_target_id_for_mappable_relations() -> None:
+    """Mappings still require target identifiers unless marked unmappable."""
+    with pytest.raises(ValueError, match="target_id is required"):
+        IdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=RelationType.primary,
+            source_id="TopVolantis",
+        )
+
+
+def test_identifier_mapping_rejects_target_for_unmappable_relation() -> None:
+    """Unmappable relations must not carry target identifier fields."""
+    with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
+        IdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=RelationType.unmappable,
+            source_id="NoMatch",
+            target_id="VOLANTIS GP. Top",
         )
 
 

--- a/tests/test_models/test_mappings.py
+++ b/tests/test_models/test_mappings.py
@@ -112,6 +112,9 @@ def test_identifier_mapping_ids_not_empty_strings() -> None:
 def test_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None:
     """Source and target identifiers are stripped when they contain padding."""
     mapping = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=RelationType.primary,
         source_id="  TopVolantis  ",
         target_id="  VOLANTIS GP. Top  ",
     )
@@ -123,7 +126,9 @@ def test_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None:
 def test_identifier_mapping_allows_same_system_primary_mapping_to_itself() -> None:
     """Same-system primary mappings must map an identifier to itself."""
     mapping = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="TopVolantis",
     )
@@ -141,7 +146,9 @@ def test_identifier_mapping_rejects_same_system_primary_to_other_identifier() ->
         ),
     ):
         create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
             target_system=DataSystem.rms,
+            relation_type=RelationType.primary,
             source_id="TopVolantis",
             target_id="TopVolon",
         )
@@ -150,6 +157,7 @@ def test_identifier_mapping_rejects_same_system_primary_to_other_identifier() ->
 def test_identifier_mapping_allows_same_system_alias() -> None:
     """Same-system aliases can point to a primary identifier."""
     mapping = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
         relation_type=RelationType.alias,
         source_id="TOP_VOLANTIS",
@@ -170,6 +178,7 @@ def test_identifier_mapping_rejects_same_system_alias_mapping_to_itself() -> Non
         ),
     ):
         create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
             target_system=DataSystem.rms,
             relation_type=RelationType.alias,
             source_id="TopVolantis",
@@ -199,6 +208,7 @@ def test_identifier_mapping_rejects_cross_system_alias() -> None:
         match="Cross-system mapping cannot use relation_type 'alias'",
     ):
         create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
             target_system=DataSystem.smda,
             relation_type=RelationType.alias,
             source_id="TOP_VOLANTIS",
@@ -237,7 +247,13 @@ def test_identifier_mapping_allows_explicit_none_target_for_unmappable() -> None
 def test_identifier_mapping_rejects_blank_target_id() -> None:
     """Target identifiers cannot be blank when provided."""
     with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
-        create_stratigraphy_mapping(target_id="   ")
+        create_stratigraphy_mapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            relation_type=RelationType.primary,
+            source_id="TopVolantis",
+            target_id="   ",
+        )
 
 
 @pytest.mark.parametrize(
@@ -300,21 +316,55 @@ def test_stratigraphy_mappings_allow_empty_collection() -> None:
     assert len(mappings) == 0
 
 
-def test_stratigraphy_mappings_allow_valid_collection_and_dunder_methods() -> None:
-    """Stratigraphy collections allow valid rows and support dunder methods."""
+def test_stratigraphy_mappings_allow_valid_collection() -> None:
+    """Stratigraphy collections allow valid mappings."""
     primary = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="TopVolantis",
     )
     alias = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
         relation_type=RelationType.alias,
         source_id="TOP_VOLANTIS",
         target_id="TopVolantis",
     )
     mapped = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.smda,
+        relation_type=RelationType.primary,
+        source_id="TopVolantis",
+        target_id="VOLANTIS GP. Top",
+    )
+    mappings = StratigraphyMappings(root=[primary, alias, mapped])
+    expected = [primary, alias, mapped]
+
+    assert mappings.root == expected
+
+
+def test_stratigraphy_mappings_support_dunder_methods() -> None:
+    """Stratigraphy collections support the expected dunder methods."""
+    primary = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
+        source_id="TopVolantis",
+        target_id="TopVolantis",
+    )
+    alias = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        relation_type=RelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+    mapped = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="VOLANTIS GP. Top",
     )
@@ -329,6 +379,7 @@ def test_stratigraphy_mappings_allow_valid_collection_and_dunder_methods() -> No
 def test_stratigraphy_mappings_reject_alias_without_primary() -> None:
     """Same-system aliases must point to an existing same-system primary."""
     alias = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
         relation_type=RelationType.alias,
         source_id="TOP_VOLANTIS",
@@ -345,21 +396,26 @@ def test_stratigraphy_mappings_reject_alias_without_primary() -> None:
         StratigraphyMappings(root=[alias])
 
 
-def test_stratigraphy_mappings_reject_cross_system_rows_for_alias_sources() -> None:
+def test_stratigraphy_mappings_reject_cross_system_mappings_for_alias_sources() -> None:
     """Cross-system mappings must use same-system primary source identifiers."""
     primary = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="TopVolantis",
     )
     alias = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
         relation_type=RelationType.alias,
         source_id="TOP_VOLANTIS",
         target_id="TopVolantis",
     )
     mapped_alias = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.smda,
+        relation_type=RelationType.primary,
         source_id="TOP_VOLANTIS",
         target_id="VOLANTIS GP. Top",
     )
@@ -377,16 +433,21 @@ def test_stratigraphy_mappings_reject_cross_system_rows_for_alias_sources() -> N
 def test_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
     """A same-system primary identifier can only have one outcome per target system."""
     primary = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="TopVolantis",
     )
     mapped = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.smda,
+        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="VOLANTIS GP. Top",
     )
     unmappable = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.smda,
         relation_type=RelationType.unmappable,
         source_id="TopVolantis",
@@ -401,18 +462,23 @@ def test_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
 
 
 def test_stratigraphy_mappings_reject_reused_same_system_source_identifier() -> None:
-    """A source identifier cannot be both a primary and an alias in the same graph."""
+    """A source_id cannot be both a primary and an alias in the same collection."""
     primary = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="TopVolantis",
     )
     other_primary = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
         source_id="TopVolon",
         target_id="TopVolon",
     )
     conflicting_alias = create_stratigraphy_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
         relation_type=RelationType.alias,
         source_id="TopVolantis",
@@ -438,7 +504,13 @@ def test_wellbore_mapping_supports_expected_target_systems(
     target_system: DataSystem, target_id: str
 ) -> None:
     """Ensure wellbore mappings can target the supported systems."""
-    mapping = create_wellbore_mapping(target_system=target_system, target_id=target_id)
+    mapping = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=target_system,
+        relation_type=RelationType.primary,
+        source_id="30_9-B-21_C",
+        target_id=target_id,
+    )
 
     assert mapping.target_system == target_system
     assert mapping.target_id == target_id
@@ -452,20 +524,55 @@ def test_wellbore_mappings_allow_empty_collection() -> None:
     assert len(mappings) == 0
 
 
-def test_wellbore_mappings_allow_valid_collection_and_dunder_methods() -> None:
-    """Wellbore collections allow valid rows and support dunder methods."""
+def test_wellbore_mappings_allow_valid_collection() -> None:
+    """Wellbore collections allow valid mappings."""
     primary = create_wellbore_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
         source_id="30_9-B-21_C",
         target_id="30_9-B-21_C",
     )
     simulator_target = create_wellbore_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.simulator,
+        relation_type=RelationType.primary,
         source_id="30_9-B-21_C",
         target_id="B21C",
     )
     pdm_target = create_wellbore_mapping(
+        source_system=DataSystem.rms,
         target_system=DataSystem.pdm,
+        relation_type=RelationType.primary,
+        source_id="30_9-B-21_C",
+        target_id="30/9-B-21 C",
+    )
+    mappings = WellboreMappings(root=[primary, simulator_target, pdm_target])
+    expected = [primary, simulator_target, pdm_target]
+
+    assert mappings.root == expected
+
+
+def test_wellbore_mappings_support_dunder_methods() -> None:
+    """Wellbore collections support the expected dunder methods."""
+    primary = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        relation_type=RelationType.primary,
+        source_id="30_9-B-21_C",
+        target_id="30_9-B-21_C",
+    )
+    simulator_target = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.simulator,
+        relation_type=RelationType.primary,
+        source_id="30_9-B-21_C",
+        target_id="B21C",
+    )
+    pdm_target = create_wellbore_mapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.pdm,
+        relation_type=RelationType.primary,
         source_id="30_9-B-21_C",
         target_id="30/9-B-21 C",
     )

--- a/tests/test_models/test_mappings.py
+++ b/tests/test_models/test_mappings.py
@@ -1,5 +1,7 @@
 """Tests for validators in the mapping models."""
 
+from uuid import uuid4
+
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
@@ -17,26 +19,81 @@ from fmu.datamodels.context.mappings import (
 )
 
 
-def test_base_mapping_validates_systems_differ() -> None:
-    """Ensure that validation fails if a mapping maps to the same system."""
-    with pytest.raises(ValueError, match="source_system and target_system must differ"):
+def create_stratigraphy_mapping(
+    *,
+    source_system: DataSystem = DataSystem.rms,
+    target_system: DataSystem = DataSystem.smda,
+    relation_type: RelationType = RelationType.primary,
+    source_id: str = "TopVolantis",
+    target_id: str | None = "VOLANTIS GP. Top",
+) -> StratigraphyIdentifierMapping:
+    """Build a stratigraphy mapping with sensible defaults for tests."""
+    return StratigraphyIdentifierMapping(
+        source_system=source_system,
+        target_system=target_system,
+        relation_type=relation_type,
+        source_id=source_id,
+        target_id=target_id,
+    )
+
+
+def create_wellbore_mapping(
+    *,
+    source_system: DataSystem = DataSystem.rms,
+    target_system: DataSystem = DataSystem.smda,
+    relation_type: RelationType = RelationType.primary,
+    source_id: str = "30_9-B-21_C",
+    target_id: str | None = "NO 30/9-B-21 C",
+) -> WellboreIdentifierMapping:
+    """Build a wellbore mapping with sensible defaults for tests."""
+    return WellboreIdentifierMapping(
+        source_system=source_system,
+        target_system=target_system,
+        relation_type=relation_type,
+        source_id=source_id,
+        target_id=target_id,
+    )
+
+
+@pytest.mark.parametrize("relation_type", [RelationType.primary, RelationType.alias])
+def test_base_mapping_allows_same_system_primary_and_alias(
+    relation_type: RelationType,
+) -> None:
+    """Same-system primary and alias relations are allowed."""
+    BaseMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.rms,
+        mapping_type=MappingType.stratigraphy,
+        relation_type=relation_type,
+    )
+
+
+def test_base_mapping_rejects_same_system_unmappable() -> None:
+    """Unmappable is only valid for cross-system mappings."""
+    with pytest.raises(
+        ValueError,
+        match="Same-system mapping cannot use relation_type 'unmappable'",
+    ):
         BaseMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.rms,
             mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.primary,
+            relation_type=RelationType.unmappable,
         )
 
 
-def test_base_mapping_allows_fmu_to_fmu_mappings() -> None:
-    """Ensure that validation does not fail if FMU maps to FMU."""
-    # Does not raise
-    BaseMapping(
-        source_system=DataSystem.fmu,
-        target_system=DataSystem.fmu,
-        mapping_type=MappingType.stratigraphy,
-        relation_type=RelationType.primary,
-    )
+def test_base_mapping_rejects_cross_system_alias() -> None:
+    """Alias is only valid for same-system mappings."""
+    with pytest.raises(
+        ValueError,
+        match="Cross-system mapping cannot use relation_type 'alias'",
+    ):
+        BaseMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=RelationType.alias,
+        )
 
 
 def test_identifier_mapping_ids_not_empty_strings() -> None:
@@ -49,6 +106,103 @@ def test_identifier_mapping_ids_not_empty_strings() -> None:
             relation_type=RelationType.primary,
             source_id="",
             target_id="foo",
+        )
+
+
+def test_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None:
+    """Source and target identifiers are stripped when they contain padding."""
+    mapping = create_stratigraphy_mapping(
+        source_id="  TopVolantis  ",
+        target_id="  VOLANTIS GP. Top  ",
+    )
+
+    assert mapping.source_id == "TopVolantis"
+    assert mapping.target_id == "VOLANTIS GP. Top"
+
+
+def test_identifier_mapping_allows_same_system_primary_mapping_to_itself() -> None:
+    """Same-system primary mappings must map an identifier to itself."""
+    mapping = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        source_id="TopVolantis",
+        target_id="TopVolantis",
+    )
+
+    assert mapping.source_id == mapping.target_id
+
+
+def test_identifier_mapping_rejects_same_system_primary_to_other_identifier() -> None:
+    """Same-system primary mappings cannot map an identifier to another one."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Same-system primary mapping must have matching source_id and "
+            "target_id; use relation_type='alias' if they should differ"
+        ),
+    ):
+        create_stratigraphy_mapping(
+            target_system=DataSystem.rms,
+            source_id="TopVolantis",
+            target_id="TopVolon",
+        )
+
+
+def test_identifier_mapping_allows_same_system_alias() -> None:
+    """Same-system aliases can point to a primary identifier."""
+    mapping = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        relation_type=RelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+
+    assert mapping.source_id == "TOP_VOLANTIS"
+    assert mapping.target_id == "TopVolantis"
+
+
+def test_identifier_mapping_rejects_same_system_alias_mapping_to_itself() -> None:
+    """Same-system aliases must point to a different identifier."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Same-system alias mapping must have different source_id and "
+            "target_id; use relation_type='primary' if they should match"
+        ),
+    ):
+        create_stratigraphy_mapping(
+            target_system=DataSystem.rms,
+            relation_type=RelationType.alias,
+            source_id="TopVolantis",
+            target_id="TopVolantis",
+        )
+
+
+def test_identifier_mapping_rejects_same_system_unmappable() -> None:
+    """Unmappable relations are not valid for same-system mappings."""
+    with pytest.raises(
+        ValueError,
+        match="Same-system mapping cannot use relation_type 'unmappable'",
+    ):
+        IdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.rms,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=RelationType.unmappable,
+            source_id="NoMatch",
+        )
+
+
+def test_identifier_mapping_rejects_cross_system_alias() -> None:
+    """Alias relations are not valid for cross-system mappings."""
+    with pytest.raises(
+        ValueError,
+        match="Cross-system mapping cannot use relation_type 'alias'",
+    ):
+        create_stratigraphy_mapping(
+            target_system=DataSystem.smda,
+            relation_type=RelationType.alias,
+            source_id="TOP_VOLANTIS",
+            target_id="VOLANTIS GP. Top",
         )
 
 
@@ -83,24 +237,31 @@ def test_identifier_mapping_allows_explicit_none_target_for_unmappable() -> None
 def test_identifier_mapping_rejects_blank_target_id() -> None:
     """Target identifiers cannot be blank when provided."""
     with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
-        IdentifierMapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.smda,
-            mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.primary,
-            source_id="TopVolantis",
-            target_id="   ",
-        )
+        create_stratigraphy_mapping(target_id="   ")
 
 
-def test_identifier_mapping_requires_target_id_for_mappable_relations() -> None:
-    """Mappings still require target identifiers unless marked unmappable."""
-    with pytest.raises(ValueError, match="target_id is required"):
+@pytest.mark.parametrize(
+    ("target_system", "relation_type"),
+    [
+        (DataSystem.rms, RelationType.primary),
+        (DataSystem.rms, RelationType.alias),
+        (DataSystem.smda, RelationType.primary),
+    ],
+)
+def test_identifier_mapping_requires_target_id_for_non_unmappable_relations(
+    target_system: DataSystem,
+    relation_type: RelationType,
+) -> None:
+    """All non-unmappable mappings require a target identifier."""
+    with pytest.raises(
+        ValueError,
+        match="target_id is required unless relation_type is 'unmappable'",
+    ):
         IdentifierMapping(
             source_system=DataSystem.rms,
-            target_system=DataSystem.smda,
+            target_system=target_system,
             mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.primary,
+            relation_type=relation_type,
             source_id="TopVolantis",
         )
 
@@ -118,63 +279,151 @@ def test_identifier_mapping_rejects_target_for_unmappable_relation() -> None:
         )
 
 
-def test_stratigraping_mappings_accessors() -> None:
-    """Ensure all stratigraphy mapping methods work as expected."""
-    primary = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
+def test_identifier_mapping_rejects_target_uuid_for_unmappable_relation() -> None:
+    """Unmappable relations must not carry target UUID fields."""
+    with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
+        IdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            mapping_type=MappingType.stratigraphy,
+            relation_type=RelationType.unmappable,
+            source_id="NoMatch",
+            target_uuid=uuid4(),
+        )
+
+
+def test_stratigraphy_mappings_allow_empty_collection() -> None:
+    """Stratigraphy collections can be empty when no mappings exist yet."""
+    mappings = StratigraphyMappings(root=[])
+
+    assert list(mappings) == []
+    assert len(mappings) == 0
+
+
+def test_stratigraphy_mappings_allow_valid_collection_and_dunder_methods() -> None:
+    """Stratigraphy collections allow valid rows and support dunder methods."""
+    primary = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        source_id="TopVolantis",
+        target_id="TopVolantis",
+    )
+    alias = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        relation_type=RelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+    mapped = create_stratigraphy_mapping(
         target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="VOLANTIS GP. Top",
     )
-    alias1 = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.alias,
-        source_id="TopVOLANTIS",
-        target_id="VOLANTIS GP. Top",
-    )
-    alias2 = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.alias,
-        source_id="TOP_VOLANTIS",
-        target_id="VOLANTIS GP. Top",
-    )
-    mappings = StratigraphyMappings(root=[primary, alias1, alias2])
-
-    assert mappings.get_by_source(source_id="TopVOLANTIS") == [alias1]
-    assert mappings.get_by_target(target_id="VOLANTIS GP. Top") == [
-        primary,
-        alias1,
-        alias2,
-    ]
-    assert mappings.get_official_name(rms_name="TOP_VOLANTIS") == "VOLANTIS GP. Top"
-    assert mappings.get_official_name(rms_name="TOPVOLANTIS") is None
-
-
-def test_stratigrapy_mappings_dunder_methods() -> None:
-    """Ensure stratigraphy mappings support indexing, iteration, and len()."""
-    primary = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="VOLANTIS GP. Top",
-    )
-    alias = StratigraphyIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.alias,
-        source_id="TOP_VOLANTIS",
-        target_id="VOLANTIS GP. Top",
-    )
-    mappings = StratigraphyMappings(root=[primary, alias])
-    expected = [primary, alias]
+    mappings = StratigraphyMappings(root=[primary, alias, mapped])
+    expected = [primary, alias, mapped]
 
     assert mappings[0] == primary
     assert list(mappings) == expected
     assert len(mappings) == len(expected)
+
+
+def test_stratigraphy_mappings_reject_alias_without_primary() -> None:
+    """Same-system aliases must point to an existing same-system primary."""
+    alias = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        relation_type=RelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Same-system alias mappings must point to an existing "
+            "same-system primary source_id"
+        ),
+    ):
+        StratigraphyMappings(root=[alias])
+
+
+def test_stratigraphy_mappings_reject_cross_system_rows_for_alias_sources() -> None:
+    """Cross-system mappings must use same-system primary source identifiers."""
+    primary = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        source_id="TopVolantis",
+        target_id="TopVolantis",
+    )
+    alias = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        relation_type=RelationType.alias,
+        source_id="TOP_VOLANTIS",
+        target_id="TopVolantis",
+    )
+    mapped_alias = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        source_id="TOP_VOLANTIS",
+        target_id="VOLANTIS GP. Top",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cross-system mappings must use a source_id that is defined "
+            "as a same-system primary"
+        ),
+    ):
+        StratigraphyMappings(root=[primary, alias, mapped_alias])
+
+
+def test_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
+    """A same-system primary identifier can only have one outcome per target system."""
+    primary = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        source_id="TopVolantis",
+        target_id="TopVolantis",
+    )
+    mapped = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        source_id="TopVolantis",
+        target_id="VOLANTIS GP. Top",
+    )
+    unmappable = create_stratigraphy_mapping(
+        target_system=DataSystem.smda,
+        relation_type=RelationType.unmappable,
+        source_id="TopVolantis",
+        target_id=None,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=("A source_id can only have one cross-system mapping per target system"),
+    ):
+        StratigraphyMappings(root=[primary, mapped, unmappable])
+
+
+def test_stratigraphy_mappings_reject_reused_same_system_source_identifier() -> None:
+    """A source identifier cannot be both a primary and an alias in the same graph."""
+    primary = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        source_id="TopVolantis",
+        target_id="TopVolantis",
+    )
+    other_primary = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        source_id="TopVolon",
+        target_id="TopVolon",
+    )
+    conflicting_alias = create_stratigraphy_mapping(
+        target_system=DataSystem.rms,
+        relation_type=RelationType.alias,
+        source_id="TopVolantis",
+        target_id="TopVolon",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=("Same-system mappings cannot reuse the same source_id"),
+    ):
+        StratigraphyMappings(root=[primary, other_primary, conflicting_alias])
 
 
 @pytest.mark.parametrize(
@@ -189,38 +438,41 @@ def test_wellbore_mapping_supports_expected_target_systems(
     target_system: DataSystem, target_id: str
 ) -> None:
     """Ensure wellbore mappings can target the supported systems."""
-    mapping = WellboreIdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=target_system,
-        relation_type=RelationType.primary,
-        source_id="30_9-B-21_C",
-        target_id=target_id,
-    )
+    mapping = create_wellbore_mapping(target_system=target_system, target_id=target_id)
 
     assert mapping.target_system == target_system
     assert mapping.target_id == target_id
 
 
-def test_wellbore_mappings_dunder_methods() -> None:
-    """Ensure wellbore mappings support indexing, iteration, and len()."""
-    first = WellboreIdentifierMapping(
-        source_system=DataSystem.rms,
+def test_wellbore_mappings_allow_empty_collection() -> None:
+    """Wellbore collections can be empty when no mappings exist yet."""
+    mappings = WellboreMappings(root=[])
+
+    assert list(mappings) == []
+    assert len(mappings) == 0
+
+
+def test_wellbore_mappings_allow_valid_collection_and_dunder_methods() -> None:
+    """Wellbore collections allow valid rows and support dunder methods."""
+    primary = create_wellbore_mapping(
+        target_system=DataSystem.rms,
+        source_id="30_9-B-21_C",
+        target_id="30_9-B-21_C",
+    )
+    simulator_target = create_wellbore_mapping(
         target_system=DataSystem.simulator,
-        relation_type=RelationType.primary,
         source_id="30_9-B-21_C",
         target_id="B21C",
     )
-    second = WellboreIdentifierMapping(
-        source_system=DataSystem.rms,
+    pdm_target = create_wellbore_mapping(
         target_system=DataSystem.pdm,
-        relation_type=RelationType.primary,
         source_id="30_9-B-21_C",
         target_id="30/9-B-21 C",
     )
-    mappings = WellboreMappings(root=[first, second])
-    expected = [first, second]
+    mappings = WellboreMappings(root=[primary, simulator_target, pdm_target])
+    expected = [primary, simulator_target, pdm_target]
 
-    assert mappings[0] == first
+    assert mappings[0] == primary
     assert list(mappings) == expected
     assert len(mappings) == len(expected)
 


### PR DESCRIPTION
Resolves #205 

Removed equivalent and add unmappable as relation type.

For a case when an RMS zone or else cannot be mapped to SMDA, then we would map RMS to SMDA and use unmappable as relation type.

If relation type is unmappable, the target_id and target_uuid must be null. For other relation type, target_id must be present (cannot be null).

I think this is better than having a "not_mappable" data system as it's not clear it's not mappable to what.

Example entry for unmappable case in mappings.json:
```json
[
  {
    "source_system": "rms",
    "target_system": "rms",
    "source_id": "x",
    "target_id": "x",
    "relation_type": "primary"
  },
  {
    "source_system": "rms",
    "target_system": "rms",
    "source_id": "y",
    "target_id": "x",
    "relation_type": "alias"
  },
  {
    "source_system": "rms",
    "target_system": "smda",
    "source_id": "x",
    "target_id": null,
    "relation_type": "unmappable"
  }
]
```

Resolves #208 

Add validations to the mappings model

After this PR, fmu-settings and fmu-settings-api need to be updated because they still check for equivalent relation type.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅