### PR TITLE
REV: Revert back mappings model to consumer friendly format

### DIFF
--- a/src/fmu/datamodels/context/mappings.py
+++ b/src/fmu/datamodels/context/mappings.py
@@ -1,6 +1,6 @@
 """Data mapping models between systems."""
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from enum import StrEnum
 from typing import Annotated, Literal, Self
 from uuid import UUID
@@ -28,13 +28,6 @@ class RelationType(StrEnum):
     alias = "alias"
     """Alias of a primary identifier."""
 
-    unmappable = "unmappable"
-    """A source identifier that has been reviewed and cannot be mapped.
-
-    This means the identifier has been checked, but no matching identifier exists
-    in the target system.
-    """
-
 
 class DataSystem(StrEnum):
     """The system or application data is being mapping to or from."""
@@ -54,23 +47,14 @@ class BaseMapping(BaseModel):
     relation_type: RelationType
 
     @model_validator(mode="after")
-    def validate_relation_system_constraints(self) -> "BaseMapping":
-        """Validate which relation types are allowed for same vs cross-system mappings.
-
-        Same-system mappings can only be ``primary`` or ``alias``.
-        Cross-system mappings can only be ``primary`` or ``unmappable``.
-        """
+    def validate_systems_differ(self) -> "BaseMapping":
+        """Ensure source and target systems are different."""
 
         if self.source_system == self.target_system:
-            if self.relation_type == RelationType.unmappable:
-                raise ValueError(
-                    "Same-system mapping cannot use relation_type 'unmappable'"
-                )
-            return self
-
-        if self.relation_type == RelationType.alias:
-            raise ValueError("Cross-system mapping cannot use relation_type 'alias'")
-
+            raise ValueError(
+                f"source_system and target_system must differ, "
+                f"both are '{self.source_system}'"
+            )
         return self
 
 
@@ -84,69 +68,15 @@ class IdentifierMapping(BaseMapping):
 
     source_id: str
     source_uuid: UUID | None = None
-    target_id: str | None = None
+    target_id: str
     target_uuid: UUID | None = None
 
-    @field_validator("source_id")
-    def validate_source_id_not_empty(cls: Self, v: str) -> str:
-        """Ensure source IDs are not empty strings."""
+    @field_validator("source_id", "target_id")
+    def validate_ids_not_empty(cls: Self, v: str) -> str:
+        """Ensure IDs are not empty strings."""
         if not v or not v.strip():
             raise ValueError("An identifier cannot be an empty string")
         return v.strip()
-
-    @field_validator("target_id")
-    def validate_target_id_not_empty(cls: Self, v: str | None) -> str | None:
-        """Ensure target IDs are not empty strings when provided."""
-        if v is None:
-            return v
-        if not v.strip():
-            raise ValueError("An identifier cannot be an empty string")
-        return v.strip()
-
-    @model_validator(mode="after")
-    def validate_relation_target_constraints(self) -> Self:
-        """Validate how ``source_id`` and ``target_id`` are allowed to relate.
-
-        This means:
-        - ``unmappable`` mappings must leave the target empty
-        - all other mappings must provide a target
-        - same-system ``primary`` mappings must use the same ``source_id`` and
-          ``target_id``
-        - same-system ``alias`` mappings must point to a different same-system
-          ``target_id``
-        """
-        if self.relation_type == RelationType.unmappable:
-            if self.target_id is not None or self.target_uuid is not None:
-                raise ValueError(
-                    "Unmappable mapping cannot define target_id or target_uuid"
-                )
-            return self
-
-        if self.target_id is None:
-            raise ValueError(
-                "target_id is required unless relation_type is 'unmappable'"
-            )
-
-        if self.source_system == self.target_system:
-            if self.relation_type == RelationType.primary:
-                if self.source_id != self.target_id:
-                    raise ValueError(
-                        "Same-system primary mapping must have matching "
-                        "source_id and target_id; use relation_type='alias' "
-                        "if they should differ"
-                    )
-                return self
-
-            if self.relation_type == RelationType.alias:
-                if self.source_id == self.target_id:
-                    raise ValueError(
-                        "Same-system alias mapping must have different "
-                        "source_id and target_id; use relation_type='primary' "
-                        "if they should match"
-                    )
-                return self
-
-        return self
 
 
 class StratigraphyIdentifierMapping(IdentifierMapping):
@@ -174,140 +104,10 @@ AnyIdentifierMapping = Annotated[
 ]
 
 
-def _validate_identifier_mappings_collection(
-    mappings: Sequence[IdentifierMapping],
-) -> None:
-    """Validate how mappings are allowed to fit together.
-
-    The collection must satisfy three invariants:
-
-    - A same-system ``source_id`` can appear only once per mapping type.
-      Example valid mappings::
-
-          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
-          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
-
-      Example invalid mappings::
-
-          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
-          rms -> rms, alias, source_id="TopVolantis", target_id="TopVolon"
-
-      The second mapping is invalid because ``TopVolantis`` is reused as a
-      same-system ``source_id``.
-
-    - Same-system alias mappings must point to an existing same-system primary
-      mapping.
-      Example valid mappings::
-
-          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
-          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
-
-      Example invalid mapping::
-
-          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
-
-      The alias is invalid on its own because there is no same-system primary
-      mapping for ``TopVolantis``.
-
-    - Cross-system mappings must originate from a same-system primary mapping and
-      can appear only once per target system.
-      Example valid mappings::
-
-          rms -> rms, primary, source_id="TopVolantis", target_id="TopVolantis"
-          rms -> smda, primary, source_id="TopVolantis", target_id="VOLANTIS GP. Top"
-
-      Example invalid mappings::
-
-          rms -> rms, alias, source_id="TOP_VOLANTIS", target_id="TopVolantis"
-          rms -> smda, primary, source_id="TOP_VOLANTIS", target_id="VOLANTIS GP. Top"
-
-      The cross-system mapping is invalid because it starts from an alias instead
-      of a same-system primary. It is also invalid to add two ``rms -> smda``
-      mappings for the same ``source_id``.
-    """
-    same_system_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
-    same_system_primary_source_keys: set[tuple[DataSystem, MappingType, str]] = set()
-    same_system_aliases: list[IdentifierMapping] = []
-    cross_system_source_keys: set[tuple[MappingType, DataSystem, DataSystem, str]] = (
-        set()
-    )
-    cross_system_mappings: list[IdentifierMapping] = []
-
-    for mapping in mappings:
-        source_key = (
-            mapping.source_system,
-            mapping.mapping_type,
-            mapping.source_id,
-        )
-
-        # Same-system mappings tell us which source_id is the primary and which
-        # source_ids are aliases of that primary.
-        if mapping.source_system == mapping.target_system:
-            if source_key in same_system_source_keys:
-                raise ValueError("Same-system mappings cannot reuse the same source_id")
-            same_system_source_keys.add(source_key)
-
-            if mapping.relation_type == RelationType.primary:
-                same_system_primary_source_keys.add(source_key)
-            else:
-                same_system_aliases.append(mapping)
-            continue
-
-        # A source_id can map to each target system only once.
-        cross_system_key = (
-            mapping.mapping_type,
-            mapping.source_system,
-            mapping.target_system,
-            mapping.source_id,
-        )
-        if cross_system_key in cross_system_source_keys:
-            raise ValueError(
-                "A source_id can only have one cross-system mapping per target system"
-            )
-        cross_system_source_keys.add(cross_system_key)
-        cross_system_mappings.append(mapping)
-
-    # Every alias must point to a same-system primary source_id that already
-    # exists in the collection.
-    for mapping in same_system_aliases:
-        primary_target_id = mapping.target_id
-        assert primary_target_id is not None
-        primary_target_key = (
-            mapping.source_system,
-            mapping.mapping_type,
-            primary_target_id,
-        )
-        if primary_target_key not in same_system_primary_source_keys:
-            raise ValueError(
-                "Same-system alias mappings must point to an existing "
-                "same-system primary source_id"
-            )
-
-    # Cross-system mappings are only allowed when they start from a same-system
-    # primary source_id.
-    for mapping in cross_system_mappings:
-        primary_source_key = (
-            mapping.source_system,
-            mapping.mapping_type,
-            mapping.source_id,
-        )
-        if primary_source_key not in same_system_primary_source_keys:
-            raise ValueError(
-                "Cross-system mappings must use a source_id that is defined "
-                "as a same-system primary"
-            )
-
-
 class StratigraphyMappings(RootModel[list[StratigraphyIdentifierMapping]]):
     """Collection of all stratigraphy mappings."""
 
     root: list[StratigraphyIdentifierMapping]
-
-    @model_validator(mode="after")
-    def validate_collection(self) -> Self:
-        """Ensure the mapping collection follows the allowed mapping rules."""
-        _validate_identifier_mappings_collection(self.root)
-        return self
 
     def __getitem__(self: Self, index: int) -> StratigraphyIdentifierMapping:
         """Retrieves a stratigraphy mapping from the list using the specified index."""
@@ -328,15 +128,6 @@ class WellboreMappings(RootModel[list[WellboreIdentifierMapping]]):
     """Collection of all wellbore mappings."""
 
     root: list[WellboreIdentifierMapping]
-
-    @model_validator(mode="after")
-    def validate_collection(self) -> Self:
-        """Ensure the mapping collection follows the allowed mapping rules."""
-        # Wellbore mappings are not expected to use aliases today, but reusing the
-        # shared identifier-mapping rules keeps the validation consistent if that
-        # changes later.
-        _validate_identifier_mappings_collection(self.root)
-        return self
 
     def __getitem__(self: Self, index: int) -> WellboreIdentifierMapping:
         """Retrieves a wellbore mapping from the list using the specified index."""

--- a/tests/test_models/test_mappings.py
+++ b/tests/test_models/test_mappings.py
@@ -1,7 +1,5 @@
 """Tests for validators in the mapping models."""
 
-from uuid import uuid4
-
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
@@ -19,80 +17,14 @@ from fmu.datamodels.context.mappings import (
 )
 
 
-def create_stratigraphy_mapping(
-    *,
-    source_system: DataSystem = DataSystem.rms,
-    target_system: DataSystem = DataSystem.smda,
-    relation_type: RelationType = RelationType.primary,
-    source_id: str = "TopVolantis",
-    target_id: str | None = "VOLANTIS GP. Top",
-) -> StratigraphyIdentifierMapping:
-    """Build a stratigraphy mapping with sensible defaults for tests."""
-    return StratigraphyIdentifierMapping(
-        source_system=source_system,
-        target_system=target_system,
-        relation_type=relation_type,
-        source_id=source_id,
-        target_id=target_id,
-    )
-
-
-def create_wellbore_mapping(
-    *,
-    source_system: DataSystem = DataSystem.rms,
-    target_system: DataSystem = DataSystem.smda,
-    relation_type: RelationType = RelationType.primary,
-    source_id: str = "30_9-B-21_C",
-    target_id: str | None = "NO 30/9-B-21 C",
-) -> WellboreIdentifierMapping:
-    """Build a wellbore mapping with sensible defaults for tests."""
-    return WellboreIdentifierMapping(
-        source_system=source_system,
-        target_system=target_system,
-        relation_type=relation_type,
-        source_id=source_id,
-        target_id=target_id,
-    )
-
-
-@pytest.mark.parametrize("relation_type", [RelationType.primary, RelationType.alias])
-def test_base_mapping_allows_same_system_primary_and_alias(
-    relation_type: RelationType,
-) -> None:
-    """Same-system primary and alias relations are allowed."""
-    BaseMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        mapping_type=MappingType.stratigraphy,
-        relation_type=relation_type,
-    )
-
-
-def test_base_mapping_rejects_same_system_unmappable() -> None:
-    """Unmappable is only valid for cross-system mappings."""
-    with pytest.raises(
-        ValueError,
-        match="Same-system mapping cannot use relation_type 'unmappable'",
-    ):
+def test_base_mapping_validates_systems_differ() -> None:
+    """Ensure that validation fails if a mapping maps to the same system."""
+    with pytest.raises(ValueError, match="source_system and target_system must differ"):
         BaseMapping(
             source_system=DataSystem.rms,
             target_system=DataSystem.rms,
             mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.unmappable,
-        )
-
-
-def test_base_mapping_rejects_cross_system_alias() -> None:
-    """Alias is only valid for same-system mappings."""
-    with pytest.raises(
-        ValueError,
-        match="Cross-system mapping cannot use relation_type 'alias'",
-    ):
-        BaseMapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.smda,
-            mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.alias,
+            relation_type=RelationType.primary,
         )
 
 
@@ -109,387 +41,28 @@ def test_identifier_mapping_ids_not_empty_strings() -> None:
         )
 
 
-def test_identifier_mapping_strips_surrounding_whitespace_from_ids() -> None:
-    """Source and target identifiers are stripped when they contain padding."""
-    mapping = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="  TopVolantis  ",
-        target_id="  VOLANTIS GP. Top  ",
-    )
-
-    assert mapping.source_id == "TopVolantis"
-    assert mapping.target_id == "VOLANTIS GP. Top"
-
-
-def test_identifier_mapping_allows_same_system_primary_mapping_to_itself() -> None:
-    """Same-system primary mappings must map an identifier to itself."""
-    mapping = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="TopVolantis",
-    )
-
-    assert mapping.source_id == mapping.target_id
-
-
-def test_identifier_mapping_rejects_same_system_primary_to_other_identifier() -> None:
-    """Same-system primary mappings cannot map an identifier to another one."""
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Same-system primary mapping must have matching source_id and "
-            "target_id; use relation_type='alias' if they should differ"
-        ),
-    ):
-        create_stratigraphy_mapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.rms,
-            relation_type=RelationType.primary,
-            source_id="TopVolantis",
-            target_id="TopVolon",
-        )
-
-
-def test_identifier_mapping_allows_same_system_alias() -> None:
-    """Same-system aliases can point to a primary identifier."""
-    mapping = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.alias,
-        source_id="TOP_VOLANTIS",
-        target_id="TopVolantis",
-    )
-
-    assert mapping.source_id == "TOP_VOLANTIS"
-    assert mapping.target_id == "TopVolantis"
-
-
-def test_identifier_mapping_rejects_same_system_alias_mapping_to_itself() -> None:
-    """Same-system aliases must point to a different identifier."""
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Same-system alias mapping must have different source_id and "
-            "target_id; use relation_type='primary' if they should match"
-        ),
-    ):
-        create_stratigraphy_mapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.rms,
-            relation_type=RelationType.alias,
-            source_id="TopVolantis",
-            target_id="TopVolantis",
-        )
-
-
-def test_identifier_mapping_rejects_same_system_unmappable() -> None:
-    """Unmappable relations are not valid for same-system mappings."""
-    with pytest.raises(
-        ValueError,
-        match="Same-system mapping cannot use relation_type 'unmappable'",
-    ):
-        IdentifierMapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.rms,
-            mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.unmappable,
-            source_id="NoMatch",
-        )
-
-
-def test_identifier_mapping_rejects_cross_system_alias() -> None:
-    """Alias relations are not valid for cross-system mappings."""
-    with pytest.raises(
-        ValueError,
-        match="Cross-system mapping cannot use relation_type 'alias'",
-    ):
-        create_stratigraphy_mapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.smda,
-            relation_type=RelationType.alias,
-            source_id="TOP_VOLANTIS",
-            target_id="VOLANTIS GP. Top",
-        )
-
-
-def test_identifier_mapping_allows_unmappable_without_target() -> None:
-    """An unmappable relation can omit target identifier fields."""
-    mapping = IdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        mapping_type=MappingType.stratigraphy,
-        relation_type=RelationType.unmappable,
-        source_id="NoMatch",
-    )
-
-    assert mapping.target_id is None
-    assert mapping.target_uuid is None
-
-
-def test_identifier_mapping_allows_explicit_none_target_for_unmappable() -> None:
-    """An unmappable relation also accepts an explicit null target identifier."""
-    mapping = IdentifierMapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        mapping_type=MappingType.stratigraphy,
-        relation_type=RelationType.unmappable,
-        source_id="NoMatch",
-        target_id=None,
-    )
-
-    assert mapping.target_id is None
-
-
-def test_identifier_mapping_rejects_blank_target_id() -> None:
-    """Target identifiers cannot be blank when provided."""
-    with pytest.raises(ValueError, match="An identifier cannot be an empty string"):
-        create_stratigraphy_mapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.smda,
-            relation_type=RelationType.primary,
-            source_id="TopVolantis",
-            target_id="   ",
-        )
-
-
-@pytest.mark.parametrize(
-    ("target_system", "relation_type"),
-    [
-        (DataSystem.rms, RelationType.primary),
-        (DataSystem.rms, RelationType.alias),
-        (DataSystem.smda, RelationType.primary),
-    ],
-)
-def test_identifier_mapping_requires_target_id_for_non_unmappable_relations(
-    target_system: DataSystem,
-    relation_type: RelationType,
-) -> None:
-    """All non-unmappable mappings require a target identifier."""
-    with pytest.raises(
-        ValueError,
-        match="target_id is required unless relation_type is 'unmappable'",
-    ):
-        IdentifierMapping(
-            source_system=DataSystem.rms,
-            target_system=target_system,
-            mapping_type=MappingType.stratigraphy,
-            relation_type=relation_type,
-            source_id="TopVolantis",
-        )
-
-
-def test_identifier_mapping_rejects_target_for_unmappable_relation() -> None:
-    """Unmappable relations must not carry target identifier fields."""
-    with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
-        IdentifierMapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.smda,
-            mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.unmappable,
-            source_id="NoMatch",
-            target_id="VOLANTIS GP. Top",
-        )
-
-
-def test_identifier_mapping_rejects_target_uuid_for_unmappable_relation() -> None:
-    """Unmappable relations must not carry target UUID fields."""
-    with pytest.raises(ValueError, match="Unmappable mapping cannot define"):
-        IdentifierMapping(
-            source_system=DataSystem.rms,
-            target_system=DataSystem.smda,
-            mapping_type=MappingType.stratigraphy,
-            relation_type=RelationType.unmappable,
-            source_id="NoMatch",
-            target_uuid=uuid4(),
-        )
-
-
-def test_stratigraphy_mappings_allow_empty_collection() -> None:
-    """Stratigraphy collections can be empty when no mappings exist yet."""
-    mappings = StratigraphyMappings(root=[])
-
-    assert list(mappings) == []
-    assert len(mappings) == 0
-
-
-def test_stratigraphy_mappings_allow_valid_collection() -> None:
-    """Stratigraphy collections allow valid mappings."""
-    primary = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="TopVolantis",
-    )
-    alias = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.alias,
-        source_id="TOP_VOLANTIS",
-        target_id="TopVolantis",
-    )
-    mapped = create_stratigraphy_mapping(
+def test_stratigraphy_mappings_dunder_methods() -> None:
+    """Ensure stratigraphy mappings support indexing, iteration, and len()."""
+    primary = StratigraphyIdentifierMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
         relation_type=RelationType.primary,
         source_id="TopVolantis",
         target_id="VOLANTIS GP. Top",
     )
-    mappings = StratigraphyMappings(root=[primary, alias, mapped])
-    expected = [primary, alias, mapped]
-
-    assert mappings.root == expected
-
-
-def test_stratigraphy_mappings_support_dunder_methods() -> None:
-    """Stratigraphy collections support the expected dunder methods."""
-    primary = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="TopVolantis",
-    )
-    alias = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.alias,
-        source_id="TOP_VOLANTIS",
-        target_id="TopVolantis",
-    )
-    mapped = create_stratigraphy_mapping(
+    alias = StratigraphyIdentifierMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
+        relation_type=RelationType.alias,
+        source_id="TOP_VOLANTIS",
         target_id="VOLANTIS GP. Top",
     )
-    mappings = StratigraphyMappings(root=[primary, alias, mapped])
-    expected = [primary, alias, mapped]
+    mappings = StratigraphyMappings(root=[primary, alias])
+    expected = [primary, alias]
 
     assert mappings[0] == primary
     assert list(mappings) == expected
     assert len(mappings) == len(expected)
-
-
-def test_stratigraphy_mappings_reject_alias_without_primary() -> None:
-    """Same-system aliases must point to an existing same-system primary."""
-    alias = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.alias,
-        source_id="TOP_VOLANTIS",
-        target_id="TopVolantis",
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Same-system alias mappings must point to an existing "
-            "same-system primary source_id"
-        ),
-    ):
-        StratigraphyMappings(root=[alias])
-
-
-def test_stratigraphy_mappings_reject_cross_system_mappings_for_alias_sources() -> None:
-    """Cross-system mappings must use same-system primary source identifiers."""
-    primary = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="TopVolantis",
-    )
-    alias = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.alias,
-        source_id="TOP_VOLANTIS",
-        target_id="TopVolantis",
-    )
-    mapped_alias = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TOP_VOLANTIS",
-        target_id="VOLANTIS GP. Top",
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Cross-system mappings must use a source_id that is defined "
-            "as a same-system primary"
-        ),
-    ):
-        StratigraphyMappings(root=[primary, alias, mapped_alias])
-
-
-def test_stratigraphy_mappings_reject_multiple_cross_system_outcomes() -> None:
-    """A same-system primary identifier can only have one outcome per target system."""
-    primary = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="TopVolantis",
-    )
-    mapped = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="VOLANTIS GP. Top",
-    )
-    unmappable = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-        relation_type=RelationType.unmappable,
-        source_id="TopVolantis",
-        target_id=None,
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=("A source_id can only have one cross-system mapping per target system"),
-    ):
-        StratigraphyMappings(root=[primary, mapped, unmappable])
-
-
-def test_stratigraphy_mappings_reject_reused_same_system_source_identifier() -> None:
-    """A source_id cannot be both a primary and an alias in the same collection."""
-    primary = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="TopVolantis",
-        target_id="TopVolantis",
-    )
-    other_primary = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="TopVolon",
-        target_id="TopVolon",
-    )
-    conflicting_alias = create_stratigraphy_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.alias,
-        source_id="TopVolantis",
-        target_id="TopVolon",
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=("Same-system mappings cannot reuse the same source_id"),
-    ):
-        StratigraphyMappings(root=[primary, other_primary, conflicting_alias])
 
 
 @pytest.mark.parametrize(
@@ -504,7 +77,7 @@ def test_wellbore_mapping_supports_expected_target_systems(
     target_system: DataSystem, target_id: str
 ) -> None:
     """Ensure wellbore mappings can target the supported systems."""
-    mapping = create_wellbore_mapping(
+    mapping = WellboreIdentifierMapping(
         source_system=DataSystem.rms,
         target_system=target_system,
         relation_type=RelationType.primary,
@@ -516,70 +89,26 @@ def test_wellbore_mapping_supports_expected_target_systems(
     assert mapping.target_id == target_id
 
 
-def test_wellbore_mappings_allow_empty_collection() -> None:
-    """Wellbore collections can be empty when no mappings exist yet."""
-    mappings = WellboreMappings(root=[])
-
-    assert list(mappings) == []
-    assert len(mappings) == 0
-
-
-def test_wellbore_mappings_allow_valid_collection() -> None:
-    """Wellbore collections allow valid mappings."""
-    primary = create_wellbore_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="30_9-B-21_C",
-        target_id="30_9-B-21_C",
-    )
-    simulator_target = create_wellbore_mapping(
+def test_wellbore_mappings_dunder_methods() -> None:
+    """Ensure wellbore mappings support indexing, iteration, and len()."""
+    first = WellboreIdentifierMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.simulator,
         relation_type=RelationType.primary,
         source_id="30_9-B-21_C",
         target_id="B21C",
     )
-    pdm_target = create_wellbore_mapping(
+    second = WellboreIdentifierMapping(
         source_system=DataSystem.rms,
         target_system=DataSystem.pdm,
         relation_type=RelationType.primary,
         source_id="30_9-B-21_C",
         target_id="30/9-B-21 C",
     )
-    mappings = WellboreMappings(root=[primary, simulator_target, pdm_target])
-    expected = [primary, simulator_target, pdm_target]
+    mappings = WellboreMappings(root=[first, second])
+    expected = [first, second]
 
-    assert mappings.root == expected
-
-
-def test_wellbore_mappings_support_dunder_methods() -> None:
-    """Wellbore collections support the expected dunder methods."""
-    primary = create_wellbore_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.rms,
-        relation_type=RelationType.primary,
-        source_id="30_9-B-21_C",
-        target_id="30_9-B-21_C",
-    )
-    simulator_target = create_wellbore_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.simulator,
-        relation_type=RelationType.primary,
-        source_id="30_9-B-21_C",
-        target_id="B21C",
-    )
-    pdm_target = create_wellbore_mapping(
-        source_system=DataSystem.rms,
-        target_system=DataSystem.pdm,
-        relation_type=RelationType.primary,
-        source_id="30_9-B-21_C",
-        target_id="30/9-B-21 C",
-    )
-    mappings = WellboreMappings(root=[primary, simulator_target, pdm_target])
-    expected = [primary, simulator_target, pdm_target]
-
-    assert mappings[0] == primary
+    assert mappings[0] == first
     assert list(mappings) == expected
     assert len(mappings) == len(expected)
 


### PR DESCRIPTION
Resolves #219 

Revert back mappings model to the consumer friendly format. The internal mappings model that was here will be moved to `fmu-settings`.

Current validation rules:

1. source and target system must differ
2. source_id and target_id are required, stripped, and non-blank

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅