### PR TITLE
CI: Run verify breaking changes workflow on main commit

### DIFF
--- a/.github/workflows/verify-breaking-changes.yml
+++ b/.github/workflows/verify-breaking-changes.yml
@@ -1,49 +1,19 @@
 name: Verify breaking changes
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  wait-for-pypi:
-    name: Wait for published package on PyPI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait up to 5 minutes for package on PyPI
-        env:
-          PACKAGE_VERSION: ${{ github.event.release.tag_name }}
-        run: |
-          python -m venv .pypi-check
-          . .pypi-check/bin/activate
-          python -m pip install --upgrade pip
-
-          deadline=$((SECONDS + 300))
-          mkdir -p pypi-dist
-
-          while true; do
-            rm -rf pypi-dist/*
-
-            if python -m pip download --no-deps --dest pypi-dist "fmu-datamodels==$PACKAGE_VERSION"; then
-              echo "fmu-datamodels==$PACKAGE_VERSION is available on PyPI."
-              break
-            fi
-
-            if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "Timed out after 300 seconds waiting for fmu-datamodels==$PACKAGE_VERSION on PyPI." >&2
-              exit 1
-            fi
-
-            echo "Package not visible on PyPI yet. Retrying..."
-            sleep 5
-          done
-
   verify-downstream:
     name: Verify ${{ matrix.repository }} on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    needs: wait-for-pypi
     strategy:
       fail-fast: false
       matrix:
@@ -66,12 +36,16 @@ jobs:
             test-command: uv run --no-sync pytest -n auto tests --cov=src/ --cov-report term-missing
 
     steps:
+      - name: Check out fmu-datamodels
+        uses: actions/checkout@v6
+
       - name: Check out downstream repository
         uses: actions/checkout@v6
         with:
           repository: ${{ matrix.repository }}
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
+          path: downstream
 
       - name: Install uv and Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v7
@@ -84,16 +58,17 @@ jobs:
           ${{ matrix.system-dependencies }}
 
       - name: Install downstream repository dependencies
+        working-directory: downstream
         run: |
           uv sync --all-extras --frozen
 
-      - name: Install released fmu-datamodels from PyPI
-        env:
-          PACKAGE_VERSION: ${{ github.event.release.tag_name }}
+      - name: Install fmu-datamodels from main
+        working-directory: downstream
         run: |
-          uv pip install --upgrade --reinstall-package fmu-datamodels "fmu-datamodels==$PACKAGE_VERSION"
+          uv pip install --upgrade --reinstall-package fmu-datamodels ..
 
       - name: Run downstream test suite
+        working-directory: downstream
         run: |
           ${{ matrix.test-setup-command }}
           ${{ matrix.test-command }}

--- a/.github/workflows/verify-breaking-changes.yml
+++ b/.github/workflows/verify-breaking-changes.yml
@@ -3,8 +3,6 @@ name: Verify breaking changes
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Resolves #222 

Also added manual workflow trigger so it can be run on PR branch if the author wants to trigger it. Workflow is verified to install from main in https://github.com/equinor/fmu-datamodels/actions/runs/25921262527

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅