### PR TITLE
MAINT: Fix typo

### DIFF
--- a/src/fmu/datamodels/standard_results/enums.py
+++ b/src/fmu/datamodels/standard_results/enums.py
@@ -174,7 +174,7 @@ class SimulatorTables:
     """Enumerations relevant to tables extracted from a flow simulator."""
 
     class ProductionNetworkColumns(IndexColumnsStrEnum):
-        """The index columns for a lift curves table."""
+        """The index columns for a production network table."""
 
         DATE = "DATE"
         CHILD = "CHILD"
@@ -188,7 +188,7 @@ class SimulatorTables:
         KEYWORD = "KEYWORD"
 
     class TransmissibilitiesColumns(IndexColumnsStrEnum):
-        """The index columns for a pvt table."""
+        """The index columns for a transmissibilities table."""
 
         DIR = "DIR"
 


### PR DESCRIPTION
Resolves #232 

Fixed typo in `ProductionNetworkColumns` and `TransmissibilitiesColumns` description. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅