### PR TITLE
ENH: Add lift curves index columns

### DIFF
--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -51,6 +51,7 @@ class FmuResultsSchema(SchemaBase):
     
     - Added 'observations_breakthrough' standard result for Ert breakthrough 
     observations.
+    - Added index columns for lift curves table. 
 
     #### 0.21.0
 

--- a/src/fmu/datamodels/standard_results/enums.py
+++ b/src/fmu/datamodels/standard_results/enums.py
@@ -173,6 +173,19 @@ class SimulatorFipregionsMapping:
 class SimulatorTables:
     """Enumerations relevant to tables extracted from a flow simulator."""
 
+    class LiftCurvesColumns(IndexColumnsStrEnum):
+        """The index columns for a lift curves table."""
+
+        TABLE_NUMBER = "TABLE_NUMBER"
+        VFP_TYPE = "VFP_TYPE"
+        RATE_TYPE = "RATE_TYPE"
+        WFR_TYPE = "WFR_TYPE"
+        GFR_TYPE = "GFR_TYPE"
+        ALQ_TYPE = "ALQ_TYPE"
+        PRESSURE_TYPE = "PRESSURE_TYPE"
+        TAB_TYPE = "TAB_TYPE"
+        UNIT_TYPE = "UNIT_TYPE"
+
     class ProductionNetworkColumns(IndexColumnsStrEnum):
         """The index columns for a production network table."""
 


### PR DESCRIPTION
Resolves #167 

Added the index columns for the `lift_curves` standard results. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅