### PR TITLE
MAINT: Declare None for coordinates

### DIFF
--- a/schemas/file_formats/0.1.0/ert_observations_breakthrough.json
+++ b/schemas/file_formats/0.1.0/ert_observations_breakthrough.json
@@ -4,12 +4,28 @@
       "description": "Represents the columns of a row in a Ert breakthrough observation export.\n\nThese fields are the current agreed upon standard result. Changes to the fields or\ntheir validation should cause the version defined in the standard result schema to\nincrease the version number in a way that corresponds to the schema versioning\nspecification (i.e. they are a patch, minor, or major change).",
       "properties": {
         "east": {
-          "title": "East",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "East"
         },
         "north": {
-          "title": "North",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "North"
         },
         "observation_error": {
           "title": "Observation Error",
@@ -38,9 +54,7 @@
         "time",
         "observation_value",
         "observation_error",
-        "threshold",
-        "east",
-        "north"
+        "threshold"
       ],
       "title": "ErtObservationsBreakthroughResultRow",
       "type": "object"

--- a/src/fmu/datamodels/standard_results/ert_observations_breakthrough.py
+++ b/src/fmu/datamodels/standard_results/ert_observations_breakthrough.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, Field, RootModel
 
 from fmu.datamodels._schema_base import FMU_SCHEMAS_PATH, SchemaBase
 from fmu.datamodels.types import VersionStr
@@ -31,11 +31,11 @@ class ErtObservationsBreakthroughResultRow(BaseModel):
     threshold: float
     """The threshold value this row represents. Required."""
 
-    east: float
-    """The east coordinate this row represents. Required."""
+    east: float | None = Field(default=None)
+    """The east coordinate this row represents. Optional."""
 
-    north: float
-    """The north coordinate this row represents. Required."""
+    north: float | None = Field(default=None)
+    """The north coordinate this row represents. Optional."""
 
 
 class ErtObservationsBreakthroughResult(RootModel):


### PR DESCRIPTION
Resolves #236 

The coordinate are put as field and defaulted to None. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅