### PR TITLE
ENH: add description field to Ensemble model

### DIFF
--- a/schemas/0.22.0/fmu_results.json
+++ b/schemas/0.22.0/fmu_results.json
@@ -1141,6 +1141,21 @@
     "Ensemble": {
       "description": "Ensemble information present as both ``fmu.ensemble`` and ``ert.ensemble``.\n\nAlthough ensemble information may be present in both blocks, within the same\nexperiment they are inconsistent.\n\n- In the FMU context, as ``fmu.ensemble``, this name is derived from the run path.\n  The ``name`` is derived from the run path, and the uuid is derived from the case\n  uuid and the ``name``.\n- In the Ert context, as ``ert.ensemble``, this name is derived from Ert UI\n  configuration and is consistent with what's inside of the Ert storage. The\n  ensemble uuid may differ within the same case if there are multiple reruns, as\n  each run of an experiment generates a new ensemble uuid in the storage.\n\nNote that this is true mostly for the ``ensemble`` context. It means that\n``fmu.ensemble`` != ``ert.ensemble``.",
       "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
         "id": {
           "anyOf": [
             {

--- a/src/fmu/datamodels/fmu_results/fields.py
+++ b/src/fmu/datamodels/fmu_results/fields.py
@@ -207,6 +207,9 @@ class Ensemble(BaseModel):
     Deprecated.
     """
 
+    description: list[str] | None = Field(default=None)
+    """A free-text description of this ensemble."""
+
 
 class Model(BaseModel):
     """The ``fmu.model`` block contains information about the model used.

--- a/src/fmu/datamodels/fmu_results/fmu_results.py
+++ b/src/fmu/datamodels/fmu_results/fmu_results.py
@@ -52,6 +52,8 @@ class FmuResultsSchema(SchemaBase):
     - Added 'observations_breakthrough' standard result for Ert breakthrough 
     observations.
     - Added index columns for lift curves table. 
+    - Added `fmu.ensemble.description` an optional field for free-text
+      description of ensemble.
 
     #### 0.21.0
 


### PR DESCRIPTION
Closes #231

Resolves #issue

Added an optional `description` field (`list[str] | None`) to the `Ensemble` model. Updated the schema to reflect this change.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅