### PR TITLE
CI: Add note to prepare schema release PR

### DIFF
--- a/.github/workflows/prepare-schema-release.yml
+++ b/.github/workflows/prepare-schema-release.yml
@@ -55,6 +55,8 @@ jobs:
       run: |
 
         body=$(cat <<EOF
+        ⚠️ This PR should only be merged as part of the release manager duty.
+
         Release a new schema to staging with the changes from release tag ${{ inputs.release_tag }}.
 
         ⚠️ Merging this PR will automatically deploy the changes to the schema applications staging environment in Radix.


### PR DESCRIPTION
Resolves #243 

Added note to the prepare schema release PR description field to only merge PR as part of the release manager duty.

## Checklist

- [ ] Tests added (if not, comment why): Only CI
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅